### PR TITLE
Remove dependency on axgen, within axeval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10368,7 +10368,6 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.5.8",
-        "axgen": "file:../axgen",
         "chalk": "^4.1.2",
         "dotenv": "^16.3.1"
       },
@@ -12403,7 +12402,6 @@
       "version": "file:packages/axeval",
       "requires": {
         "@anthropic-ai/sdk": "^0.5.8",
-        "axgen": "file:../axgen",
         "chalk": "^4.1.2",
         "dotenv": "^16.3.1",
         "prettier": "^2.8.8",

--- a/packages/axeval/example/chat.ts
+++ b/packages/axeval/example/chat.ts
@@ -2,12 +2,12 @@ import * as Path from 'node:path';
 import fs from 'fs';
 import readline from 'readline';
 import { ChatTestSuite } from '../src/suite';
-import { OpenAIChatCompletion, OpenAIChatCompletionMessageInput } from 'axgen';
+import { OpenAIChatMessage, OpenAIChat } from '../src/model';
 import { ChatEvalCase } from '../src/evalCase';
 import { Match } from '../src/evalFunction';
 
 interface JsonLDChat {
-  input: OpenAIChatCompletionMessageInput[];
+  input: OpenAIChatMessage[];
   ideal: string;
   threshhold: number;
 }
@@ -25,13 +25,9 @@ async function readJsonL(file: string): Promise<JsonLDChat[]> {
 }
 
 const evalModel = {
-  run: async (messages: OpenAIChatCompletionMessageInput[]) => {
-    const chatModel = new OpenAIChatCompletion({
-      model: 'gpt-4',
-      max_tokens: 1000,
-    });
-    const result = await chatModel.run(messages);
-    return result.choices[0].message.content || '';
+  run: async (messages: OpenAIChatMessage[]) => {
+    const chatModel = new OpenAIChat('gpt-4', { max_tokens: 300 });
+    return chatModel.run(messages);
   },
 };
 

--- a/packages/axeval/package.json
+++ b/packages/axeval/package.json
@@ -35,7 +35,6 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.5.8",
-    "axgen": "file:../axgen",
     "chalk": "^4.1.2",
     "dotenv": "^16.3.1"
   },

--- a/packages/axeval/src/evalCase.ts
+++ b/packages/axeval/src/evalCase.ts
@@ -1,16 +1,16 @@
 import type { EvalResult } from './evalResult';
 import { EvalFunction } from './evalFunction';
-import { OpenAIChatCompletionMessageInput } from 'axgen';
+import { OpenAIChatMessage } from './model';
 
 export interface EvalCase {
   description?: string;
-  prompt: string | OpenAIChatCompletionMessageInput[];
+  prompt: string | OpenAIChatMessage[];
   idealOutput: string;
   evalFunctions: EvalFunction[];
 }
 
 export interface ChatEvalCase extends EvalCase {
-  prompt: OpenAIChatCompletionMessageInput[];
+  prompt: OpenAIChatMessage[];
   idealOutput: string;
   evalFunctions: EvalFunction[];
 }
@@ -22,13 +22,13 @@ export interface CompletionEvalCase extends EvalCase {
 }
 
 export class ChatEvalCase implements EvalCase {
-  prompt: OpenAIChatCompletionMessageInput[];
+  prompt: OpenAIChatMessage[];
   idealOutput: string;
   evalFunctions: EvalFunction[];
   evalResults: EvalResult[] = [];
 
   constructor(
-    messages: OpenAIChatCompletionMessageInput[],
+    messages: OpenAIChatMessage[],
     idealOutput: string,
     evalFunctions: EvalFunction[] = []
   ) {


### PR DESCRIPTION
We were using the openAI chat model, but we can remove the dependency (which is philosophically important, given the modular goal of the ax framework), and simplify the interface, since we don't care about e.g. streaming.