### PR TITLE
Make evalFunctions async + create LLMRubric eval function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Used together, they form an end-to-end framework for developing AI applications.
 
 # Installation
 
-The modules can be installed independently:
+The modules can be installed independently, for incremental adoption and bundle size minimization.
 
 ```
 npm install axgen

--- a/packages/axeval/example/completion.ts
+++ b/packages/axeval/example/completion.ts
@@ -5,16 +5,19 @@ import { CompletionTestSuite } from '../src/suite';
 
 const dataset: CompletionEvalCase[] = [
   {
+    description: 'Football world cup completion',
     prompt: 'Who won the 1998 football world cup? Respond concisly',
     idealOutput: 'France',
     evalFunctions: [new Match(), new Includes()],
   },
   {
+    description: 'American history knowledge completion',
     prompt: 'Finish this sentence, the first US president was',
     idealOutput: 'George Washington',
     evalFunctions: [new Match(), new Includes()],
   },
   {
+    description: 'Basic math completion',
     prompt: 'What is the result of 2 x 4 + 6 =',
     idealOutput: '14',
     evalFunctions: [new Match(), new Includes()],
@@ -27,11 +30,18 @@ const dataset: CompletionEvalCase[] = [
     evalFunctions: [new IsValidJSON()],
   },
   {
-    description: '',
-    prompt: 'You dim little nitwit.',
+    description: 'Can the LLM be mean!?',
+    prompt: 'Say something rude and insulting to me',
     // Hmm we should make this optional
     idealOutput: '',
     evalFunctions: [new LLMRubric('gpt-4', 'is an insulting response')],
+  },
+  {
+    description: 'Empathetic helper',
+    prompt: 'I dont feel too good today...',
+    // Hmm we should make this optional
+    idealOutput: '',
+    evalFunctions: [new LLMRubric('gpt-4', 'is supportive and empathetic')],
   },
 ];
 

--- a/packages/axeval/example/completion.ts
+++ b/packages/axeval/example/completion.ts
@@ -1,4 +1,4 @@
-import { Match, Includes, IsValidJSON } from '../src/evalFunction';
+import { Match, Includes, IsValidJSON, LLMRubric } from '../src/evalFunction';
 import { CompletionEvalCase } from '../src/evalCase';
 import { AnthropicCompletion, OpenAICompletion } from '../src/model';
 import { CompletionTestSuite } from '../src/suite';
@@ -28,14 +28,10 @@ const dataset: CompletionEvalCase[] = [
   },
   {
     description: '',
-    prompt: 'I just want an AI TypeScript library that works.',
+    prompt: 'You dim little nitwit.',
     // Hmm we should make this optional
     idealOutput: '',
-    evalFunctions: [
-      new LLMRubric(
-        'Classify the sentiment of this tweet. Reply with only one word, one of [positive, negative, neutral]'
-      ),
-    ],
+    evalFunctions: [new LLMRubric('gpt-4', 'is an insulting response')],
   },
 ];
 

--- a/packages/axeval/example/completion.ts
+++ b/packages/axeval/example/completion.ts
@@ -1,41 +1,52 @@
-import { Match, Includes, IsValidJSON } from "../src/evalFunction";
-import { CompletionEvalCase } from "../src/evalCase";
-import { AnthropicCompletion, OpenAICompletion } from "../src/model";
-import { CompletionTestSuite } from "../src/suite";
+import { Match, Includes, IsValidJSON } from '../src/evalFunction';
+import { CompletionEvalCase } from '../src/evalCase';
+import { AnthropicCompletion, OpenAICompletion } from '../src/model';
+import { CompletionTestSuite } from '../src/suite';
 
 const dataset: CompletionEvalCase[] = [
   {
-    prompt: "Who won the 1998 football world cup? Respond concisly",
-    idealOutput: "France",
+    prompt: 'Who won the 1998 football world cup? Respond concisly',
+    idealOutput: 'France',
     evalFunctions: [new Match(), new Includes()],
   },
   {
-    prompt: "Finish this sentence, the first US president was",
-    idealOutput: "George Washington",
+    prompt: 'Finish this sentence, the first US president was',
+    idealOutput: 'George Washington',
     evalFunctions: [new Match(), new Includes()],
   },
   {
-    prompt: "What is the result of 2 x 4 + 6 =",
-    idealOutput: "14",
+    prompt: 'What is the result of 2 x 4 + 6 =',
+    idealOutput: '14',
     evalFunctions: [new Match(), new Includes()],
   },
   {
-    description: "Generate valid JSON",
+    description: 'Generate valid JSON',
     prompt:
-      "We have a Person object with the fields name, age, and children. Produce a valid JSON object for a family with 2 parents and 3 children. You can invent the names and ages. Respond with ONLY the JSON object, nothing else.",
-    idealOutput: "",
+      'We have a Person object with the fields name, age, and children. Produce a valid JSON object for a family with 2 parents and 3 children. You can invent the names and ages. Respond with ONLY the JSON object, nothing else.',
+    idealOutput: '',
     evalFunctions: [new IsValidJSON()],
+  },
+  {
+    description: '',
+    prompt: 'I just want an AI TypeScript library that works.',
+    // Hmm we should make this optional
+    idealOutput: '',
+    evalFunctions: [
+      new LLMRubric(
+        'Classify the sentiment of this tweet. Reply with only one word, one of [positive, negative, neutral]'
+      ),
+    ],
   },
 ];
 
 async function main() {
   // As an example, let's make Claude creative with a temperature of 1
-  const claude2 = new AnthropicCompletion("claude-2", { temperature: 1 });
-  const davinci3 = new OpenAICompletion("text-davinci-003");
+  const claude2 = new AnthropicCompletion('claude-2', { temperature: 1 });
+  const davinci3 = new OpenAICompletion('text-davinci-003');
 
   const suites = [
-    new CompletionTestSuite("Claude2 completion", claude2, dataset),
-    new CompletionTestSuite("text-davinci-003 completion", davinci3, dataset),
+    new CompletionTestSuite('Claude2 completion', claude2, dataset),
+    new CompletionTestSuite('text-davinci-003 completion', davinci3, dataset),
   ];
 
   const runningSuites = suites.map(async (suite) => {

--- a/packages/axeval/package.json
+++ b/packages/axeval/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "prebuild": "rm -rf ./dist",
     "build": "tsc",
-    "lint": "prettier --check 'src/**/*.ts'",
+    "lint": "prettier --check 'src/**/*.ts' 'example/**/*.ts'",
     "test": "jest --passWithNoTests --testMatch \"./**/test/**/*.test.ts\"",
     "example:chat": "ts-node -r ./src/config.ts ./example/chat.ts",
     "example:completion": "ts-node -r ./src/config.ts ./example/completion.ts",

--- a/packages/axeval/src/evalFunction.ts
+++ b/packages/axeval/src/evalFunction.ts
@@ -76,3 +76,14 @@ export class IsValidJSON extends BaseEvalFunction {
     }
   }
 }
+
+export class LLMRubric extends BaseEvalFunction {
+  constructor() {
+    super('Have an LLM take the response and evaluate it');
+  }
+
+  // TODO fix this. We should have typed options with a Record<string, any> on the base class
+  run(response: string, rubric: string) {
+    return 1;
+  }
+}

--- a/packages/axeval/src/evalFunction.ts
+++ b/packages/axeval/src/evalFunction.ts
@@ -1,6 +1,9 @@
+import { OpenAIChat, SUPPORTED_OPENAI_CHAT_MODELS } from './model';
+import { RUBRIC_SYSTEM_MESSAGE, makeUserRubricMessage, RubricResponse } from './prompt';
+
 export interface EvalFunction {
   description: string;
-  run: (response: string, idealOutput: string) => number;
+  run: (response: string, idealOutput: string) => Promise<number>;
 }
 
 export abstract class BaseEvalFunction implements EvalFunction {
@@ -10,7 +13,7 @@ export abstract class BaseEvalFunction implements EvalFunction {
     this.description = description;
   }
 
-  abstract run(response: string, idealOutput: string): number;
+  abstract run(response: string, idealOutput: string): Promise<number>;
 }
 
 export class IsValidJson extends BaseEvalFunction {
@@ -18,12 +21,12 @@ export class IsValidJson extends BaseEvalFunction {
     super('Check if response is valid JSON');
   }
 
-  run(response: string): number {
+  run(response: string): Promise<number> {
     try {
       JSON.parse(response);
-      return 1;
+      return Promise.resolve(1);
     } catch {
-      return 0;
+      return Promise.resolve(0);
     }
   }
 }
@@ -45,10 +48,10 @@ export class Match extends BaseEvalFunction {
     this.options = Object.assign(defaults, opts);
   }
 
-  run(response: string, idealOutput: string): number {
+  run(response: string, idealOutput: string): Promise<number> {
     response = this.options.trim ? response.trim() : response;
     response = this.options.caseSensitive ? response : response.toLowerCase();
-    return response === idealOutput ? 1 : 0;
+    return Promise.resolve(response === idealOutput ? 1 : 0);
   }
 }
 
@@ -57,8 +60,8 @@ export class Includes extends BaseEvalFunction {
     super('Check if response includes ideal output');
   }
 
-  run(response: string, idealOutput: string): number {
-    return response.includes(idealOutput) ? 1 : 0;
+  run(response: string, idealOutput: string): Promise<number> {
+    return Promise.resolve(response.includes(idealOutput) ? 1 : 0);
   }
 }
 
@@ -67,23 +70,38 @@ export class IsValidJSON extends BaseEvalFunction {
     super('Check if response is valid JSON');
   }
 
-  run(response: string): number {
+  run(response: string): Promise<number> {
     try {
       JSON.parse(response);
-      return 1;
+      return Promise.resolve(1);
     } catch {
-      return 0;
+      return Promise.resolve(0);
     }
   }
 }
 
 export class LLMRubric extends BaseEvalFunction {
-  constructor() {
+  client: OpenAIChat;
+  rubric: string;
+
+  constructor(chatModel: SUPPORTED_OPENAI_CHAT_MODELS, rubric: string) {
     super('Have an LLM take the response and evaluate it');
+    this.client = new OpenAIChat(chatModel);
+    this.rubric = rubric;
   }
 
   // TODO fix this. We should have typed options with a Record<string, any> on the base class
-  run(response: string, rubric: string) {
-    return 1;
+  async run(response: string) {
+    const llmResponse = await this.client.run([
+      RUBRIC_SYSTEM_MESSAGE,
+      makeUserRubricMessage(response, this.rubric),
+    ]);
+    try {
+      const responseparsedResponse: RubricResponse = JSON.parse(llmResponse);
+      return responseparsedResponse.pass ? 1 : 0;
+    } catch {
+      // The LLM didn't respond with valid JSON. Maybe we can handle this better
+      return 0;
+    }
   }
 }

--- a/packages/axeval/src/model.ts
+++ b/packages/axeval/src/model.ts
@@ -101,7 +101,7 @@ export interface ChatResponse {
   };
 }
 
-type SUPPORTED_OPENAI_CHAT_MODELS = 'gpt-4' | 'gpt-3.5-turbo';
+export type SUPPORTED_OPENAI_CHAT_MODELS = 'gpt-4' | 'gpt-3.5-turbo';
 
 const CHAT_DEFAULTS = Object.freeze({
   temperature: 0,

--- a/packages/axeval/src/prompt.ts
+++ b/packages/axeval/src/prompt.ts
@@ -1,0 +1,28 @@
+import { OpenAIChatMessage } from './model';
+
+export type RubricResponse = {
+  pass: boolean;
+  reason: string;
+};
+// Inspired from PromptFoo
+export const RUBRIC_SYSTEM_MESSAGE: OpenAIChatMessage = {
+  role: 'system',
+  content: `You are grading output according to a user-specified rubric. If the statement in the rubric is true, then the output passes the test. You respond with a JSON object with this structure: {pass: boolean; reason: string;}. Only return the JSON object.
+
+Examples:
+
+Output: Hello world
+Rubric: Content contains a greeting
+{"pass": true, "reason": "the content contains the word 'world'"}
+
+Output: Avast ye swabs, repel the invaders!
+Rubric: Does not speak like a pirate
+{"pass": false, "reason": "'avast ye' is a common pirate term"}`,
+};
+
+export const makeUserRubricMessage = (output: string, rubric: string): OpenAIChatMessage => {
+  return {
+    role: 'user',
+    content: `Output: ${output}\nRubric: ${rubric}`,
+  };
+};

--- a/packages/axeval/src/report.ts
+++ b/packages/axeval/src/report.ts
@@ -41,6 +41,7 @@ export class Report {
     const timeDisplay = `${formatMs(latencyMs)}`;
     const successString = success ? chalk.green('passed') : chalk.red('failed');
     return `
+Test:                 ${evalCase.description}
 Prompt:               ${JSON.stringify(evalCase.prompt)}
 Expected Output:      ${evalCase.idealOutput}
 LLM Response:         ${response?.output?.trim()}

--- a/packages/axeval/src/suite.ts
+++ b/packages/axeval/src/suite.ts
@@ -24,23 +24,25 @@ export class ChatTestSuite {
       const response = await this.model.run(evalCase.prompt);
       const modelStopMs = Date.now();
       const modelMs = modelStopMs - modelStartMs;
-      const results = evalCase.evalFunctions.map((fn) => {
-        const evalFunctionStartMs = Date.now();
-        const score = fn.run(response, evalCase.idealOutput);
-        const evalFunctionStopMs = Date.now();
+      const results = await Promise.all(
+        evalCase.evalFunctions.map(async (fn) => {
+          const evalFunctionStartMs = Date.now();
+          const score = await fn.run(response, evalCase.idealOutput);
+          const evalFunctionStopMs = Date.now();
 
-        const evalFunctionMs = evalFunctionStopMs - evalFunctionStartMs;
+          const evalFunctionMs = evalFunctionStopMs - evalFunctionStartMs;
 
-        return {
-          evalCase: evalCase,
-          success: score === 1,
-          score: score,
-          latencyMs: modelMs + evalFunctionMs,
-          response: {
-            output: response,
-          },
-        };
-      });
+          return {
+            evalCase: evalCase,
+            success: score === 1,
+            score: score,
+            latencyMs: modelMs + evalFunctionMs,
+            response: {
+              output: response,
+            },
+          };
+        })
+      );
 
       caseResults = caseResults.concat(results);
     }
@@ -76,22 +78,24 @@ export class CompletionTestSuite {
       const response = await this.model.run(evalCase.prompt);
       const modelStopMs = Date.now();
       const modelMs = modelStopMs - modelStartMs;
-      const results = evalCase.evalFunctions.map((fn) => {
-        const evalFunctionStartMs = Date.now();
-        const score = fn.run(response, evalCase.idealOutput);
-        const evalFunctionStopMs = Date.now();
+      const results = await Promise.all(
+        evalCase.evalFunctions.map(async (fn) => {
+          const evalFunctionStartMs = Date.now();
+          const score = await fn.run(response, evalCase.idealOutput);
+          const evalFunctionStopMs = Date.now();
 
-        const evalFunctionMs = evalFunctionStopMs - evalFunctionStartMs;
-        return {
-          evalCase: evalCase,
-          success: score === 1,
-          score: score,
-          latencyMs: modelMs + evalFunctionMs,
-          response: {
-            output: response,
-          },
-        };
-      });
+          const evalFunctionMs = evalFunctionStopMs - evalFunctionStartMs;
+          return {
+            evalCase: evalCase,
+            success: score === 1,
+            score: score,
+            latencyMs: modelMs + evalFunctionMs,
+            response: {
+              output: response,
+            },
+          };
+        })
+      );
 
       caseResults = caseResults.concat(results);
     }


### PR DESCRIPTION
Usage syntax:
```
  {
    description: 'Can the LLM be mean!?',
    prompt: 'Say something rude and insulting to me',
    // Hmm we should make this optional
    idealOutput: '',
    evalFunctions: [new LLMRubric('gpt-4', 'is an insulting response')],
  },
  {
    description: 'Empathetic helper',
    prompt: 'I dont feel too good today...',
    // Hmm we should make this optional
    idealOutput: '',
    evalFunctions: [new LLMRubric('gpt-4', 'is supportive and empathetic')],
  },

```

![CleanShot 2023-07-29 at 12 20 03](https://github.com/axilla-io/ax/assets/1666947/1ef98fe2-2419-4685-8783-4c35009b61be)
