### PR TITLE
Custom report for each evalResult based on evalFunction type

### DIFF
--- a/packages/axeval/example/completion.ts
+++ b/packages/axeval/example/completion.ts
@@ -1,4 +1,4 @@
-import { Match, Includes, IsValidJSON, LLMRubric } from '../src/evalFunction';
+import { Match, Includes, IsValidJson, LLMRubric } from '../src/evalFunction';
 import { CompletionEvalCase } from '../src/evalCase';
 import { AnthropicCompletion, OpenAICompletion } from '../src/model';
 import { CompletionTestSuite } from '../src/suite';
@@ -27,7 +27,7 @@ const dataset: CompletionEvalCase[] = [
     prompt:
       'We have a Person object with the fields name, age, and children. Produce a valid JSON object for a family with 2 parents and 3 children. You can invent the names and ages. Respond with ONLY the JSON object, nothing else.',
     idealOutput: '',
-    evalFunctions: [new IsValidJSON()],
+    evalFunctions: [new IsValidJson()],
   },
   {
     description: 'Can the LLM be mean!?',

--- a/packages/axeval/src/evalResult.ts
+++ b/packages/axeval/src/evalResult.ts
@@ -15,6 +15,10 @@ export interface ProviderResponse {
 
 export interface EvalResult {
   evalCase: EvalCase;
+  evalFunction: {
+    id: string;
+    args?: any[];
+  };
   response?: ProviderResponse;
   error?: string;
   success: boolean;

--- a/packages/axeval/src/report.ts
+++ b/packages/axeval/src/report.ts
@@ -27,33 +27,41 @@ export interface EvalCaseReport {
 export class DefaultEvalCaseReport implements EvalCaseReport {
   constructor(private result: EvalResult) {}
   print() {
-    const { success, response, score, evalCase, latencyMs } = this.result;
+    const { success, response, evalFunction, score, evalCase, latencyMs } = this.result;
 
     const timeDisplay = `${formatMs(latencyMs)}`;
     const successString = success ? chalk.green('passed') : chalk.red('failed');
-    return `
-Test:                 ${evalCase.description}
+    const firstLine = evalCase.description ? `Test:                 ${evalCase.description}\n` : ``;
+    return (
+      firstLine +
+      `
+EvalFunction:         ${evalFunction.id}
 Prompt:               ${JSON.stringify(evalCase.prompt)}
 Expected Output:      ${evalCase.idealOutput}
 LLM Response:         ${response?.output?.trim()}
 Score:                ${score} (${successString})
-Time:                 ${timeDisplay}`;
+Time:                 ${timeDisplay}`
+    );
   }
 }
 
 export class LLMRubricReport implements EvalCaseReport {
   constructor(private result: EvalResult) {}
   print() {
-    const { success, response, score, evalCase, latencyMs } = this.result;
+    const { success, response, score, evalFunction, evalCase, latencyMs } = this.result;
 
     const timeDisplay = `${formatMs(latencyMs)}`;
     const successString = success ? chalk.green('passed') : chalk.red('failed');
-    return `
-Test:                 ${evalCase.description}
+    const firstLine = evalCase.description ? `Test:                 ${evalCase.description}\n` : ``;
+    return (
+      firstLine +
+      `
+EvalFunction:         ${evalFunction.id}
 Prompt:               ${JSON.stringify(evalCase.prompt)}
 LLM Response:         ${response?.output?.trim()}
 Score:                ${score} (${successString})
-Time:                 ${timeDisplay}`;
+Time:                 ${timeDisplay}`
+    );
   }
 }
 

--- a/packages/axeval/src/report.ts
+++ b/packages/axeval/src/report.ts
@@ -20,6 +20,43 @@ function formatMs(ms: number) {
   }
 }
 
+export interface EvalCaseReport {
+  print: () => string;
+}
+
+export class DefaultEvalCaseReport implements EvalCaseReport {
+  constructor(private result: EvalResult) {}
+  print() {
+    const { success, response, score, evalCase, latencyMs } = this.result;
+
+    const timeDisplay = `${formatMs(latencyMs)}`;
+    const successString = success ? chalk.green('passed') : chalk.red('failed');
+    return `
+Test:                 ${evalCase.description}
+Prompt:               ${JSON.stringify(evalCase.prompt)}
+Expected Output:      ${evalCase.idealOutput}
+LLM Response:         ${response?.output?.trim()}
+Score:                ${score} (${successString})
+Time:                 ${timeDisplay}`;
+  }
+}
+
+export class LLMRubricReport implements EvalCaseReport {
+  constructor(private result: EvalResult) {}
+  print() {
+    const { success, response, score, evalCase, latencyMs } = this.result;
+
+    const timeDisplay = `${formatMs(latencyMs)}`;
+    const successString = success ? chalk.green('passed') : chalk.red('failed');
+    return `
+Test:                 ${evalCase.description}
+Prompt:               ${JSON.stringify(evalCase.prompt)}
+LLM Response:         ${response?.output?.trim()}
+Score:                ${score} (${successString})
+Time:                 ${timeDisplay}`;
+  }
+}
+
 export class Report {
   description: string;
   timeMs: number;
@@ -35,18 +72,13 @@ export class Report {
     this.failed = this.results.filter((result) => !result.success);
   }
 
-  evalResultToString(result: EvalResult) {
-    const { success, response, score, evalCase, latencyMs } = result;
-
-    const timeDisplay = `${formatMs(latencyMs)}`;
-    const successString = success ? chalk.green('passed') : chalk.red('failed');
-    return `
-Test:                 ${evalCase.description}
-Prompt:               ${JSON.stringify(evalCase.prompt)}
-Expected Output:      ${evalCase.idealOutput}
-LLM Response:         ${response?.output?.trim()}
-Score:                ${score} (${successString})
-Time:                 ${timeDisplay}`;
+  evalResultToString(result: EvalResult): string {
+    switch (result.evalFunction.id) {
+      case 'llm-rubric':
+        return new LLMRubricReport(result).print();
+      default:
+        return new DefaultEvalCaseReport(result).print();
+    }
   }
 
   toString(verbose: boolean = false) {

--- a/packages/axeval/src/suite.ts
+++ b/packages/axeval/src/suite.ts
@@ -34,6 +34,9 @@ export class ChatTestSuite {
 
           return {
             evalCase: evalCase,
+            evalFunction: {
+              id: fn.id,
+            },
             success: score === 1,
             score: score,
             latencyMs: modelMs + evalFunctionMs,
@@ -87,6 +90,7 @@ export class CompletionTestSuite {
           const evalFunctionMs = evalFunctionStopMs - evalFunctionStartMs;
           return {
             evalCase: evalCase,
+            evalFunction: { id: fn.id },
             success: score === 1,
             score: score,
             latencyMs: modelMs + evalFunctionMs,


### PR DESCRIPTION
Introducing a pattern that allows each evalFunction type to return a custom report.

For this, I need to introduce a unique ID on each evalFunction.
Currently, nothing makes sure that the id isn't registered... I considered adding a type but it felt heavy.. curious what you think

![CleanShot 2023-07-29 at 12 54 14](https://github.com/axilla-io/ax/assets/1666947/13d16c2e-6541-4dab-b089-1d620c29705b)
