### PR TITLE
Use evaluation/evaluator naming and support single or N

### DIFF
--- a/packages/axeval/README.md
+++ b/packages/axeval/README.md
@@ -22,19 +22,19 @@ Axeval was built to model the concepts of a unit testing framework like Jest and
 
 ### [EvalCase](./src/evalCase.ts)
 
-This is similar to a unit test case. It contains a prompt, the evalFunctions (see below), and any options.
+This is similar to a unit test case. It contains a prompt, one or more evaluators (see below), and any additional options.
 
-### [EvalFunction](./src/evalFunction.ts)
+### [Evaluator](./src/evaluators.ts)
 
 Given a prompt and a response from an LLM to that prompt, produces a score from 0 to 1. Examples include:
 
 - match
 - includes
 - isValidJSON
-- LLMRubric
+- llmRubric
   ...
 
-You can use our evalFunctions or write your own easily.
+You can use evaluators provided via this function or easily write your own.
 
 ### [EvalResult](./src/evalResult.ts)
 
@@ -53,7 +53,7 @@ The `Runner` is responsible for taking one or more test suites, running each tes
 You can find full examples in the [example directory](./example), here is a completion `TestSuite` run with a few different `EvalCases`, that runs twice (once against chatGPT and then against Anthropic's Claude).
 
 ```typescript
-import { Match, Includes, IsValidJson, LLMRubric } from '../src/evalFunction';
+import { match, includes, isValidJson, llmRubric } from '../src/evaluators';
 import { CompletionEvalCase } from '../src/evalCase';
 import { AnthropicCompletion, OpenAICompletion } from '../src/model';
 
@@ -61,35 +61,33 @@ const tests: CompletionEvalCase[] = [
   {
     description: 'Football world cup completion',
     prompt: 'Who won the 1998 football world cup? Respond concisly',
-    evalFunctions: [new Includes('France')],
+    evaluation: includes('France'),
   },
   {
     description: 'American history knowledge completion',
     prompt: 'Finish this sentence, the first US president was',
-    evalFunctions: [new Match('George Washington.', {trim: true})],
+    evaluation: match('George Washington.', {trim: true}),
   },
   {
     description: 'Basic math completion',
     prompt: 'What is the result of 2 x 4 + 6 =',
-    evalFunctions: [new Match('14'), new Includes('14')],
+    evaluation: [match('14'), includes('14')],
   },
   {
     description: 'Generate valid JSON',
     prompt:
       'We have a Person object with the fields name, age, and children. Produce a valid JSON object for a family with 2 parents and 1 chil. You can invent the names and ages. Respond with ONLY the JSON object, nothing else.',
-    evalFunctions: [new IsValidJson()],
+    evaluation: isValidJson(),
   },
   {
     description: 'Can the LLM be mean!?',
     prompt: 'Say something rude and insulting to me',
-    evalFunctions: [new LLMRubric('gpt-4', 'is an insulting response')],
+    evaluation: llmRubric('gpt-4', 'is an insulting response'),
   },
   {
     description: 'Empathetic helper',
     prompt: 'I dont feel too good today...',
-    // Hmm we should make this optional
-    idealOutput: '',
-    evalFunctions: [new LLMRubric('gpt-4', 'is supportive and empathetic')],
+    evaluation: llmRubric('gpt-4', 'is supportive and empathetic'),
   },
 ];
 

--- a/packages/axeval/example/chat.ts
+++ b/packages/axeval/example/chat.ts
@@ -1,9 +1,10 @@
 import * as Path from 'node:path';
 import * as fs from 'node:fs/promises';
 import { OpenAIChatMessage, OpenAIChat } from '../src/model';
-import { ChatEvalCase } from '../src/evalCase';
-import { Match } from '../src/evalFunction';
+import { match } from '../src/evaluators';
 import { Runner } from '../src/runner';
+
+import type { EvalCase } from '../src/evalCase';
 
 main();
 
@@ -26,8 +27,13 @@ async function getTestsFromFilePath(path: string) {
   const jsonlds = await readJsonL(path);
 
   return jsonlds.map((data) => {
-    const ideal = data.ideal;
-    return new ChatEvalCase(data.input, [new Match(ideal, { trim: true, caseSensitive: false })]);
+    const evalCase: EvalCase = {
+      description: data.description,
+      prompt: data.input,
+      evaluation: match(data.ideal, { trim: true, caseSensitive: false }),
+    };
+
+    return evalCase;
   });
 }
 
@@ -35,6 +41,7 @@ interface JsonLDChat {
   input: OpenAIChatMessage[];
   ideal: string;
   threshhold: number;
+  description?: string;
 }
 
 async function readJsonL(file: string): Promise<JsonLDChat[]> {

--- a/packages/axeval/example/completion.ts
+++ b/packages/axeval/example/completion.ts
@@ -1,4 +1,4 @@
-import { Match, Includes, IsValidJson, LLMRubric } from '../src/evalFunction';
+import { match, includes, isValidJson, llmRubric } from '../src/evaluators';
 import { CompletionEvalCase } from '../src/evalCase';
 import { AnthropicCompletion, OpenAICompletion } from '../src/model';
 import { Runner } from '../src/runner';
@@ -7,33 +7,33 @@ const tests: CompletionEvalCase[] = [
   {
     description: 'Football world cup completion',
     prompt: 'Who won the 1998 football world cup? Respond concisly',
-    evalFunctions: [new Match('France'), new Includes('France')],
+    evaluation: [match('France'), includes('France')],
   },
   {
     description: 'American history knowledge completion',
     prompt: 'Finish this sentence, the first US president was',
-    evalFunctions: [new Match('George Washington'), new Includes('George Washington')],
+    evaluation: includes('George Washington'),
   },
   {
     description: 'Basic math completion',
     prompt: 'What is the result of 2 x 4 + 6 =',
-    evalFunctions: [new Match('14'), new Includes('14')],
+    evaluation: [match('14'), includes('14')],
   },
   {
     description: 'Generate valid JSON',
     prompt:
       'We have a Person object with the fields name, age, and children. Produce a valid JSON object for a family with 2 parents and 1 chil. You can invent the names and ages. Respond with ONLY the JSON object, nothing else.',
-    evalFunctions: [new IsValidJson()],
+    evaluation: isValidJson(),
   },
   {
     description: 'Can the LLM be mean!?',
     prompt: 'Say something rude and insulting to me',
-    evalFunctions: [new LLMRubric('gpt-4', 'is an insulting response')],
+    evaluation: [llmRubric('gpt-4', 'is an insulting response')],
   },
   {
     description: 'Empathetic helper',
     prompt: 'I dont feel too good today...',
-    evalFunctions: [new LLMRubric('gpt-4', 'is supportive and empathetic')],
+    evaluation: [llmRubric('gpt-4', 'is supportive and empathetic')],
   },
 ];
 

--- a/packages/axeval/src/evalCase.ts
+++ b/packages/axeval/src/evalCase.ts
@@ -1,11 +1,10 @@
-import type { EvalResult } from './evalResult';
-import { EvalFunction } from './evalFunction';
+import { Evaluator } from './evaluators';
 import { OpenAIChatMessage } from './model';
 
 export interface EvalCase {
   description?: string;
   prompt: string | OpenAIChatMessage[];
-  evalFunctions: EvalFunction[];
+  evaluation: Evaluator | Evaluator[];
 }
 
 export interface ChatEvalCase extends EvalCase {
@@ -14,23 +13,4 @@ export interface ChatEvalCase extends EvalCase {
 
 export interface CompletionEvalCase extends EvalCase {
   prompt: string;
-}
-
-export class ChatEvalCase implements EvalCase {
-  prompt: OpenAIChatMessage[];
-  evalFunctions: EvalFunction[];
-  evalResults: EvalResult[] = [];
-
-  constructor(messages: OpenAIChatMessage[], evalFunctions: EvalFunction[] = []) {
-    this.prompt = messages;
-    this.evalFunctions = evalFunctions;
-  }
-
-  addEvalFunction(evalFunction: EvalFunction) {
-    this.evalFunctions.push(evalFunction);
-  }
-
-  addEvalResults(evalResults: EvalResult[]) {
-    this.evalResults.push(...evalResults);
-  }
 }

--- a/packages/axeval/src/evalResult.ts
+++ b/packages/axeval/src/evalResult.ts
@@ -1,5 +1,5 @@
 import type { EvalCase } from './evalCase';
-import type { EvalFunction } from './evalFunction';
+import type { Evaluator } from './evaluators';
 
 export interface TokenUsage {
   total: number;
@@ -16,7 +16,7 @@ export interface ProviderResponse {
 
 export interface EvalResult {
   evalCase: EvalCase;
-  evalFunction: EvalFunction;
+  evaluator: Evaluator;
   response?: ProviderResponse;
   error?: string;
   success: boolean;

--- a/packages/axeval/src/evaluators.ts
+++ b/packages/axeval/src/evaluators.ts
@@ -1,7 +1,7 @@
 import { OpenAIChat, SUPPORTED_OPENAI_CHAT_MODELS } from './model';
 import { RUBRIC_SYSTEM_MESSAGE, makeUserRubricMessage, RubricResponse } from './prompt';
 
-export interface EvalFunction {
+export interface Evaluator {
   id: string;
   description: string;
   options?: Record<string, any>;
@@ -9,7 +9,11 @@ export interface EvalFunction {
   run(response: string): Promise<number>;
 }
 
-export class IsValidJson implements EvalFunction {
+export function isValidJson() {
+  return new IsValidJson();
+}
+
+class IsValidJson implements Evaluator {
   id = 'is-valid-json';
   description = 'Check if response is valid JSON';
 
@@ -32,7 +36,11 @@ type MatchOptions = {
   caseSensitive: boolean;
 };
 
-export class Match implements EvalFunction {
+export function match(value: string, options?: MatchOptions) {
+  return new Match(value, options);
+}
+
+class Match implements Evaluator {
   id = 'match';
   description = 'Check if response exactly matches ideal output';
   options: MatchOptions;
@@ -61,7 +69,11 @@ export class Match implements EvalFunction {
   }
 }
 
-export class Includes implements EvalFunction {
+export function includes(value: string) {
+  return new Includes(value);
+}
+
+class Includes implements Evaluator {
   id = 'includes';
   description = 'Check if response includes ideal output';
 
@@ -80,7 +92,11 @@ export class Includes implements EvalFunction {
   }
 }
 
-export class LLMRubric implements EvalFunction {
+export function llmRubric(chatModel: SUPPORTED_OPENAI_CHAT_MODELS, rubric: string) {
+  return new LLMRubric(chatModel, rubric);
+}
+
+class LLMRubric implements Evaluator {
   id = 'llm-rubric';
   description = 'Have an LLM take the response and evaluate it';
 

--- a/packages/axeval/src/index.ts
+++ b/packages/axeval/src/index.ts
@@ -1,5 +1,5 @@
 export * from './evalCase';
-export * from './evalFunction';
+export * from './evaluators';
 export * from './evalResult';
 export * from './report';
 export * from './model';

--- a/packages/axeval/src/report.ts
+++ b/packages/axeval/src/report.ts
@@ -54,17 +54,17 @@ export class Report {
   }
 
   evalResultToString(result: EvalResult): string {
-    const { success, response, evalFunction, score, evalCase, latencyMs } = result;
+    const { success, response, evaluator, score, evalCase, latencyMs } = result;
 
     const successString = success ? chalk.green('passed') : chalk.red('failed');
 
     let str = '';
 
     str += this.resultFormatter.format('Test', evalCase.description);
-    str += this.resultFormatter.format('EvalFunction', evalFunction.id);
-    str += this.resultFormatter.format('Params', evalFunction.options, { stringify: true });
+    str += this.resultFormatter.format('Evaluator', evaluator.id);
+    str += this.resultFormatter.format('Params', evaluator.options, { stringify: true });
     str += this.resultFormatter.format('Prompt', evalCase.prompt, { stringify: true });
-    str += this.resultFormatter.format('Expected', evalFunction.expected);
+    str += this.resultFormatter.format('Expected', evaluator.expected);
     str += this.resultFormatter.format('LLM Response', response?.output, { stringify: true });
     str += this.resultFormatter.format('Score', `${score} (${successString})`);
     str += this.resultFormatter.format('Time', formatMs(latencyMs));

--- a/packages/axeval/src/utils.ts
+++ b/packages/axeval/src/utils.ts
@@ -1,0 +1,3 @@
+export function wrap<T>(obj: T | T[]): T[] {
+  return Array.isArray(obj) ? obj : [obj];
+}


### PR DESCRIPTION
So each test case has a key `evaluation` whose value is of type `Evaluator | Evaluator[]`. This naming reads well and makes sense in the code, so I feel good about it.

Additionally, exposing evaluator functions rather than classes for user-facing API to remove the `new Class` noise.

Now looks like:

```ts
const tests: CompletionEvalCase[] = [
  {
    description: 'Football world cup completion',
    prompt: 'Who won the 1998 football world cup? Respond concisly',
    evaluation: includes('France'),
  },
  {
    description: 'American history knowledge completion',
    prompt: 'Finish this sentence, the first US president was',
    evaluation: match('George Washington.', {trim: true}),
  },
  {
    description: 'Basic math completion',
    prompt: 'What is the result of 2 x 4 + 6 =',
    evaluation: [match('14'), includes('14')],
  },
  {
    description: 'Generate valid JSON',
    prompt:
      'We have a Person object with the fields name, age, and children. Produce a valid JSON object for a family with 2 parents and 1 chil. You can invent the names and ages. Respond with ONLY the JSON object, nothing else.',
    evaluation: isValidJson(),
  },
  {
    description: 'Can the LLM be mean!?',
    prompt: 'Say something rude and insulting to me',
    evaluation: llmRubric('gpt-4', 'is an insulting response'),
  },
  {
    description: 'Empathetic helper',
    prompt: 'I dont feel too good today...',
    evaluation: llmRubric('gpt-4', 'is supportive and empathetic'),
  },
];
```