### PR TITLE
Make the suite run test cases sequentially, to avoid rate limits

### DIFF
--- a/packages/axeval/src/runner.ts
+++ b/packages/axeval/src/runner.ts
@@ -42,11 +42,11 @@ export class Runner {
   }
 
   private async runSuite(suite: SuiteType) {
-    // For loops with await in them run each loop iteration one after the other, rather than in parallel.
-    const pendingCases = suite.cases.map((evalCase) => this.runCase(suite, evalCase));
-    const nested = await Promise.all(pendingCases);
-    const flattened = nested.reduce((flattened, nested) => flattened.concat(nested), []);
-    return flattened;
+    const results = [];
+    for (const evalCase of suite.cases) {
+      results.push(await this.runCase(suite, evalCase));
+    }
+    return results.flat();
   }
 
   private async runCase(suite: SuiteType, evalCase: EvalCase) {


### PR DESCRIPTION
I ran into this error:
```
I got this error btw: Number of concurrent connections to Claude exceeds your rate limit. Please try again, or contact [sales@anthropic.com](mailto:sales@anthropic.com) to discuss your options for a rate limit increase.
```

This change makes the suites run in parallel but each suite runs their evalCases sequentially. 
There is still concurrency for the evaluations for a given evalCase, but that should not often exceed 2 or 3.