### PR TITLE
Re-introduce PgVector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2779,6 +2779,14 @@
         "util": "0.10.3"
       }
     },
+    "node_modules/assert-options": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.1.tgz",
+      "integrity": "sha512-5lNGRB5g5i2bGIzb+J1QQE1iKU/WEMVBReFIc5pPDWjcPj23otPL0eI6PB2v7QPi0qU6Mhym5D3y0ZiSIOf3GA==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/assert/node_modules/inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
@@ -3287,6 +3295,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -10287,6 +10303,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "node_modules/pacote": {
       "version": "15.2.0",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-15.2.0.tgz",
@@ -10671,6 +10692,127 @@
         "worker-loader": "^1.0.0"
       }
     },
+    "node_modules/pg": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.2.tgz",
+      "integrity": "sha512-l4rmVeV8qTIrrPrIR3kZQqBgSN93331s9i6wiUiLOSk0Q7PmUxZD/m1rQI622l3NfqBby9Ar5PABfS/SulfieQ==",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.6.2",
+        "pg-pool": "^3.6.1",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-minify": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.3.tgz",
+      "integrity": "sha512-NoSsPqXxbkD8RIe+peQCqiea4QzXgosdTKY8p7PsbbGsh2F8TifDj/vJxfuR8qJwNYrijdSs7uf0tAe6WOyCsQ==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
+      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-promise": {
+      "version": "11.5.3",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.5.3.tgz",
+      "integrity": "sha512-OBrGa/fE8Sw9tGxXfI45+8sLsYXHLqc8nKWI9Kv7aFMXEWQhUNlCMBPe8m74ycjobnhYBnv4SM0/sFe35pyS8Q==",
+      "dependencies": {
+        "assert-options": "0.8.1",
+        "pg": "8.11.2",
+        "pg-minify": "1.6.3",
+        "spex": "3.3.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgpass/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/pgvector": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/pgvector/-/pgvector-0.1.4.tgz",
+      "integrity": "sha512-RjtsAZJOqTme0tk5TRa0sgYnXoYHKf9hembmHjvGc8LmBLHQr3sFpoPEi4WpHONMxvlEv/K9bHC0fzlAEExj1w==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -10727,6 +10869,41 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12183,6 +12360,14 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
       "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
+    },
+    "node_modules/spex": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.3.0.tgz",
+      "integrity": "sha512-VNiXjFp6R4ldPbVRYbpxlD35yRHceecVXlct1J4/X80KuuPnW2AXMq3sGwhnJOhKkUsOxAT6nRGfGE5pocVw5w==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/split": {
       "version": "1.0.1",
@@ -14670,7 +14855,9 @@
         "glob": "^10.3.1",
         "langchain": "^0.0.101",
         "openai": "^4.0.0-beta.7",
-        "pdf-ts": "^0.0.2"
+        "pdf-ts": "^0.0.2",
+        "pg-promise": "^11.5.3",
+        "pgvector": "^0.1.4"
       },
       "devDependencies": {
         "@types/d3-dsv": "^3.0.1",
@@ -16969,6 +17156,11 @@
         }
       }
     },
+    "assert-options": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.1.tgz",
+      "integrity": "sha512-5lNGRB5g5i2bGIzb+J1QQE1iKU/WEMVBReFIc5pPDWjcPj23otPL0eI6PB2v7QPi0qU6Mhym5D3y0ZiSIOf3GA=="
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -17057,6 +17249,8 @@
         "langchain": "^0.0.101",
         "openai": "^4.0.0-beta.7",
         "pdf-ts": "^0.0.2",
+        "pg-promise": "*",
+        "pgvector": "*",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
@@ -17464,6 +17658,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -22811,6 +23010,11 @@
         "p-reduce": "^2.0.0"
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "pacote": {
       "version": "15.2.0",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-15.2.0.tgz",
@@ -23136,6 +23340,96 @@
         "worker-loader": "^1.0.0"
       }
     },
+    "pg": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.2.tgz",
+      "integrity": "sha512-l4rmVeV8qTIrrPrIR3kZQqBgSN93331s9i6wiUiLOSk0Q7PmUxZD/m1rQI622l3NfqBby9Ar5PABfS/SulfieQ==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-cloudflare": "^1.1.1",
+        "pg-connection-string": "^2.6.2",
+        "pg-pool": "^3.6.1",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "optional": true
+    },
+    "pg-connection-string": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-minify": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.3.tgz",
+      "integrity": "sha512-NoSsPqXxbkD8RIe+peQCqiea4QzXgosdTKY8p7PsbbGsh2F8TifDj/vJxfuR8qJwNYrijdSs7uf0tAe6WOyCsQ=="
+    },
+    "pg-pool": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
+      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "requires": {}
+    },
+    "pg-promise": {
+      "version": "11.5.3",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-11.5.3.tgz",
+      "integrity": "sha512-OBrGa/fE8Sw9tGxXfI45+8sLsYXHLqc8nKWI9Kv7aFMXEWQhUNlCMBPe8m74ycjobnhYBnv4SM0/sFe35pyS8Q==",
+      "requires": {
+        "assert-options": "0.8.1",
+        "pg": "8.11.2",
+        "pg-minify": "1.6.3",
+        "spex": "3.3.0"
+      }
+    },
+    "pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "requires": {
+        "split2": "^4.1.0"
+      },
+      "dependencies": {
+        "split2": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+        }
+      }
+    },
+    "pgvector": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/pgvector/-/pgvector-0.1.4.tgz",
+      "integrity": "sha512-RjtsAZJOqTme0tk5TRa0sgYnXoYHKf9hembmHjvGc8LmBLHQr3sFpoPEi4WpHONMxvlEv/K9bHC0fzlAEExj1w=="
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -23174,6 +23468,29 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
       "peer": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prettier": {
       "version": "2.8.8",
@@ -24296,6 +24613,11 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
       "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
+    },
+    "spex": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.3.0.tgz",
+      "integrity": "sha512-VNiXjFp6R4ldPbVRYbpxlD35yRHceecVXlct1J4/X80KuuPnW2AXMq3sGwhnJOhKkUsOxAT6nRGfGE5pocVw5w=="
     },
     "split": {
       "version": "1.0.1",

--- a/packages/axgen/docs/development.md
+++ b/packages/axgen/docs/development.md
@@ -2,6 +2,26 @@
 
 ## Setup
 
+### PGVector
+
+If you plan on using postgres + pgvector, you need to have a URL to a Postgres instance with pgvector installed. To install locally, you'll need to:
+
+1. Install pgvector, e.g., `brew install pgvector`. *Note: you may need to restart your postgres server after installing this package.*
+2. Follow the [installation instructions in the pgvector README](https://github.com/pgvector/pgvector)
+3. Create a table with the proper schema (see schema below). Or use our npm `npm run vector_store:prepare -- --store=pgvector` script do so.
+
+This is the schema required by axgen (table name and vector dimension is configurable):
+
+```sql
+CREATE TABLE IF NOT EXISTS "<table name>" (
+  id TEXT PRIMARY KEY,
+  embedding VECTOR(<vector dimension>) NOT NULL,
+  text TEXT NOT NULL,
+  url TEXT NOT NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+```
+
 ## CLI
 
 There is a CLI local to this repo that is useful for testing locally.

--- a/packages/axgen/package.json
+++ b/packages/axgen/package.json
@@ -52,7 +52,9 @@
     "glob": "^10.3.1",
     "langchain": "^0.0.101",
     "openai": "^4.0.0-beta.7",
-    "pdf-ts": "^0.0.2"
+    "pdf-ts": "^0.0.2",
+    "pg-promise": "^11.5.3",
+    "pgvector": "^0.1.4"
   },
   "devDependencies": {
     "@types/d3-dsv": "^3.0.1",

--- a/packages/axgen/src/cmd/utils.ts
+++ b/packages/axgen/src/cmd/utils.ts
@@ -5,6 +5,7 @@ import { TextSplitter } from '../splitters/text';
 import { OpenAIEmbedder } from '../embedders/open-ai-embedder';
 import { Pinecone } from '../vector_stores/pinecone';
 import { Qdrant } from '../vector_stores/qdrant';
+import { PgVector } from '../vector_stores/pgvector';
 import { getEnv, getEnvOrThrow } from '../config';
 import { IVectorStore } from '../types';
 
@@ -26,6 +27,11 @@ export function getVectorStore(store: SupportedVectorStores): IVectorStore {
       return new Qdrant({
         collection: getEnvOrThrow('QDRANT_COLLECTION'),
         url: getEnvOrThrow('QDRANT_URL'),
+      });
+    case 'pgvector':
+      return new PgVector({
+        dsn: getEnvOrThrow('PG_DSN'),
+        tableName: getEnvOrThrow('PG_TABLE_NAME'),
       });
     default:
       throw new Error(`Unrecognized vector store "${store}"`);

--- a/packages/axgen/src/cmd/vector_store/prepare.ts
+++ b/packages/axgen/src/cmd/vector_store/prepare.ts
@@ -3,6 +3,7 @@ import { hideBin } from 'yargs/helpers';
 
 import { Pinecone } from '../../vector_stores/pinecone';
 import { Qdrant } from '../../vector_stores/qdrant';
+import { PgVector } from '../../vector_stores/pgvector';
 import { SUPPORTED_VECTOR_STORES, type SupportedVectorStores } from '../../vector_stores';
 import { getEnvOrThrow } from '../../config';
 
@@ -31,6 +32,12 @@ async function prepare(store: SupportedVectorStores) {
         url: getEnvOrThrow('QDRANT_URL'),
         distance: getEnvOrThrow('QDRANT_DISTANCE') as 'Cosine' | 'Euclid' | 'Dot',
         dimension: Number(getEnvOrThrow('QDRANT_DIMENSION')),
+      });
+    case 'pgvector':
+      return await PgVector.prepare({
+        tableName: getEnvOrThrow('PG_TABLE_NAME'),
+        dimension: Number(getEnvOrThrow('PG_VECTOR_DIMENSION')),
+        dsn: getEnvOrThrow('PG_DSN'),
       });
     default:
       throw new Error(`Unrecognized store "${store}"`);

--- a/packages/axgen/src/cmd/vector_store/teardown.ts
+++ b/packages/axgen/src/cmd/vector_store/teardown.ts
@@ -4,6 +4,7 @@ import { hideBin } from 'yargs/helpers';
 import { getEnvOrThrow, getEnv } from '../../config';
 import { Pinecone } from '../../vector_stores/pinecone';
 import { Qdrant } from '../../vector_stores/qdrant';
+import { PgVector } from '../../vector_stores/pgvector';
 import { SUPPORTED_VECTOR_STORES, type SupportedVectorStores } from '../../vector_stores';
 
 const argv = yargs(hideBin(process.argv))
@@ -29,6 +30,11 @@ async function teardown(store: SupportedVectorStores) {
         url: getEnvOrThrow('QDRANT_URL'),
         collection: getEnvOrThrow('QDRANT_COLLECTION'),
         apiKey: getEnv('QDRANT_API_KEY'),
+      });
+    case 'pgvector':
+      return await PgVector.teardown({
+        tableName: getEnvOrThrow('PG_TABLE_NAME'),
+        dsn: getEnvOrThrow('PG_DSN'),
       });
     default:
       throw new Error(`Unrecognized store "${store}"`);

--- a/packages/axgen/src/vector_stores/index.ts
+++ b/packages/axgen/src/vector_stores/index.ts
@@ -1,8 +1,10 @@
 import { NAME as pinecone } from './pinecone';
 import { NAME as qdrant } from './qdrant';
+import { NAME as pgvector } from './pgvector';
 
-export const SUPPORTED_VECTOR_STORES = [pinecone, qdrant] as const;
+export const SUPPORTED_VECTOR_STORES = [pinecone, qdrant, pgvector] as const;
 export type SupportedVectorStores = (typeof SUPPORTED_VECTOR_STORES)[number];
 
 export { Pinecone } from './pinecone';
 export { Qdrant } from './qdrant';
+export { PgVector } from './pgvector';

--- a/packages/axgen/src/vector_stores/pgvector.ts
+++ b/packages/axgen/src/vector_stores/pgvector.ts
@@ -1,0 +1,113 @@
+import pgpromise from 'pg-promise';
+import { IInitOptions, ParameterizedQuery } from 'pg-promise';
+import { registerType, toSql } from 'pgvector/pg';
+import type {
+  IVectorStore,
+  IVectorQueryOptions,
+  IVectorQueryResult,
+  ChunkWithEmbeddings,
+} from '../types';
+import { wrap } from '../utils';
+
+function schema(tableName: string) {
+  return `
+    CREATE TABLE IF NOT EXISTS "${tableName}" (
+      id TEXT PRIMARY KEY,
+      embedding VECTOR($1) NOT NULL,
+      text TEXT NOT NULL,
+      url TEXT NOT NULL,
+      metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+    )
+  `;
+}
+
+function getDB(dsn: string) {
+  const initOptions: IInitOptions = {
+    async connect(e) {
+      await registerType(e.client);
+    },
+  };
+
+  const pgp = pgpromise(initOptions);
+  return pgp(dsn);
+}
+
+export const NAME = 'pgvector' as const;
+
+export class PgVector implements IVectorStore {
+  static async prepare(options: { tableName: string; dimension: number; dsn: string }) {
+    if (options.dimension > 2000) {
+      throw new Error('pgvector currently only supports dimensions less than 2000');
+    }
+
+    const db = getDB(options.dsn);
+
+    await db.none('CREATE EXTENSION IF NOT EXISTS vector;');
+    await db.none(schema(options.tableName), [options.dimension]);
+  }
+
+  static async teardown(options: { tableName: string; dsn: string }) {
+    const name = options.tableName;
+    const db = getDB(options.dsn);
+    await db.none(`DROP TABLE IF EXISTS ${name};`);
+  }
+
+  private db: pgpromise.IDatabase<{}>;
+  private tableName: string;
+
+  constructor(options: { dsn: string; tableName: string }) {
+    this.db = getDB(options.dsn);
+    this.tableName = options.tableName;
+  }
+
+  async add(chunks: ChunkWithEmbeddings[]): Promise<string[]> {
+    const ids = [];
+
+    for (const chunk of chunks) {
+      ids.push(chunk.id);
+
+      // TODO make this a put_multi
+      await this.db.none(
+        `INSERT INTO ${this.tableName} (id, embedding, text, url, metadata) VALUES ($1, $2, $3, $4, $5)`,
+        [chunk.id, toSql(chunk.embeddings), chunk.text, chunk.url, chunk.metadata]
+      );
+    }
+
+    return ids;
+  }
+
+  async delete(ids: string | string[]) {
+    await this.db.result(`DELETE FROM ${this.tableName} WHERE id IN ($1:list)`, [wrap(ids)]);
+  }
+
+  async query(embedding: number[], options: IVectorQueryOptions): Promise<IVectorQueryResult[]> {
+    // Operators (https://github.com/pgvector/pgvector/#distances):
+    // '<->': L2 distance
+    // '<#>': negative inner product
+    // '<=>': cosine similarity
+    const findVectors = options.filterTerm
+      ? new ParameterizedQuery({
+          text: `SELECT * FROM ${this.tableName} WHERE metadata->>'term' = $1 ORDER BY embedding <=> $2 LIMIT $3`,
+          values: [options.filterTerm, toSql(embedding), options.topK],
+        })
+      : new ParameterizedQuery({
+          text: `SELECT * FROM ${this.tableName} ORDER BY embedding <=> $1 LIMIT $2`,
+          values: [toSql(embedding), options.topK],
+        });
+
+    const response = await this.db.any(findVectors);
+    return response.map((row) => {
+      return {
+        id: row.id,
+        chunk: {
+          id: row.id,
+          url: row.url,
+          text: row.text,
+          metadata: row.metadata,
+        },
+        // PG doesn't give us similarity
+        similarity: null,
+      };
+    });
+  }
+}

--- a/packages/axgen/tsconfig.json
+++ b/packages/axgen/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "pgvector/pg": ["node_modules/pgvector/types/pg"]
+      "pgvector/pg": ["../../node_modules/pgvector/types/pg"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
We previously supported pgvector but had to remove support due to a bug that affected es6 environments like Nextjs. We since fixed that bug upstream in (https://github.com/brianc/node-postgres/pull/3033) and are now re-introducing support for pgvector.