### PR TITLE
Add StreamToNdJson() function in axflow/models

### DIFF
--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -177,5 +177,5 @@ AnthropicCompletion.streamBytes(/* args */)
 ### @axflow/models/utils
 
 ```ts
-import {StreamToIterable, StreamToNdJson, HttpError, isHttpError} from '@axflow/models/anthropic/completion';
+import {StreamToIterable, NdJsonStream, HttpError, isHttpError} from '@axflow/models/anthropic/completion';
 ```

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -177,5 +177,5 @@ AnthropicCompletion.streamBytes(/* args */)
 ### @axflow/models/utils
 
 ```ts
-import {StreamToIterable, HttpError, isHttpError} from '@axflow/models/anthropic/completion';
+import {StreamToIterable, StreamToNdJson, HttpError, isHttpError} from '@axflow/models/anthropic/completion';
 ```

--- a/packages/models/src/utils/index.ts
+++ b/packages/models/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { HttpError, isHttpError, POST } from './http';
 
-export { StreamToIterable } from './stream';
+export { StreamToIterable, StreamToNdJson } from './stream';

--- a/packages/models/src/utils/index.ts
+++ b/packages/models/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { HttpError, isHttpError, POST } from './http';
 
-export { StreamToIterable, StreamToNdJson } from './stream';
+export { StreamToIterable, NdJsonStream } from './stream';

--- a/packages/models/src/utils/stream.ts
+++ b/packages/models/src/utils/stream.ts
@@ -35,3 +35,85 @@ async function* createIterable<T>(stream: ReadableStream<T>): AsyncIterable<T> {
     reader.releaseLock();
   }
 }
+
+type JSONValueType =
+  | null
+  | string
+  | number
+  | boolean
+  | { [x: string]: JSONValueType }
+  | Array<JSONValueType>;
+
+/**
+ * Converts a stream of JSON-serializable objects to newline-delimited JSON.
+ *
+ * Each object is wrapped with an object that specifies the `type` and references
+ * the `value`. The `type` is one of `chunk` or `data`. A type of `chunk` means that
+ * the `value` corresponds to chunks from the input stream. A type of `data` means
+ * that the `value` corresponds to the additional data provided as the second argument
+ * to this function.
+ *
+ *
+ * Example WITHOUT additional data:
+ *
+ *     const chunk = { key: 'value' };
+ *     const stream = new ReadableStream({start(con) { con.enqueue(chunk); con.close() }});
+ *     const ndJsonStream = StreamToNdJson(stream);
+ *     const entries = [];
+ *     for await (const chunk of stream) {
+ *       entry.push(new TextDecoder().decode(chunk));
+ *     }
+ *     console.log(entries); // [ "{\"type\":\"chunk\",\"value\":{\"key\":\"value\"}}\n" ]
+ *
+ *
+ * Example WITH additional data:
+ *
+ *     const chunk = { key: 'value' };
+ *     const stream = new ReadableStream({start(con) { con.enqueue(chunk); con.close() }});
+ *     const ndJsonStream = StreamToNdJson(stream, [{ extra: 'data' }]);
+ *     const entries = [];
+ *     for await (const chunk of stream) {
+ *       entry.push(new TextDecoder().decode(chunk));
+ *     }
+ *     console.log(entries); // [ "{\"type\":\"data\",\"value\":{\"extra\":\"data\"}}\n", "{\"type\":\"chunk\",\"value\":{\"key\":\"value\"}}\n" ]
+ *
+ *
+ * @param stream A readable stream of JSON-serializable chunks to encode as ndjson
+ * @param data Optional, additional data to prepend to the output stream
+ * @returns A readable stream of newline-delimited JSON
+ */
+function StreamToNdJson<T extends { [x: string]: JSONValueType }>(
+  stream: ReadableStream<T>,
+  data?: Record<string, JSONValueType> | Record<string, JSONValueType>[],
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  function serialize(obj: Record<string, JSONValueType>) {
+    const serialized = JSON.stringify(obj);
+    return encoder.encode(`${serialized}\n`);
+  }
+
+  const ndJsonEncode = new TransformStream({
+    start(controller) {
+      if (!data) {
+        return;
+      }
+
+      for (const entry of Array.isArray(data) ? data : [data]) {
+        controller.enqueue(serialize({ type: 'data', value: entry }));
+      }
+    },
+
+    transform(chunk, controller) {
+      controller.enqueue(serialize({ type: 'chunk', value: chunk }));
+    },
+  });
+
+  return stream.pipeThrough(ndJsonEncode);
+}
+
+StreamToNdJson.headers = Object.freeze({ 'Content-Type': 'application/x-ndjson' });
+
+Object.seal(StreamToNdJson);
+
+export { StreamToNdJson };

--- a/packages/models/src/utils/stream.ts
+++ b/packages/models/src/utils/stream.ts
@@ -44,76 +44,74 @@ type JSONValueType =
   | { [x: string]: JSONValueType }
   | Array<JSONValueType>;
 
-/**
- * Converts a stream of JSON-serializable objects to newline-delimited JSON.
- *
- * Each object is wrapped with an object that specifies the `type` and references
- * the `value`. The `type` is one of `chunk` or `data`. A type of `chunk` means that
- * the `value` corresponds to chunks from the input stream. A type of `data` means
- * that the `value` corresponds to the additional data provided as the second argument
- * to this function.
- *
- *
- * Example WITHOUT additional data:
- *
- *     const chunk = { key: 'value' };
- *     const stream = new ReadableStream({start(con) { con.enqueue(chunk); con.close() }});
- *     const ndJsonStream = StreamToNdJson(stream);
- *     const entries = [];
- *     for await (const chunk of stream) {
- *       entry.push(new TextDecoder().decode(chunk));
- *     }
- *     console.log(entries); // [ "{\"type\":\"chunk\",\"value\":{\"key\":\"value\"}}\n" ]
- *
- *
- * Example WITH additional data:
- *
- *     const chunk = { key: 'value' };
- *     const stream = new ReadableStream({start(con) { con.enqueue(chunk); con.close() }});
- *     const ndJsonStream = StreamToNdJson(stream, [{ extra: 'data' }]);
- *     const entries = [];
- *     for await (const chunk of stream) {
- *       entry.push(new TextDecoder().decode(chunk));
- *     }
- *     console.log(entries); // [ "{\"type\":\"data\",\"value\":{\"extra\":\"data\"}}\n", "{\"type\":\"chunk\",\"value\":{\"key\":\"value\"}}\n" ]
- *
- *
- * @param stream A readable stream of JSON-serializable chunks to encode as ndjson
- * @param data Optional, additional data to prepend to the output stream
- * @returns A readable stream of newline-delimited JSON
- */
-function StreamToNdJson<T extends { [x: string]: JSONValueType }>(
-  stream: ReadableStream<T>,
-  data?: Record<string, JSONValueType> | Record<string, JSONValueType>[],
-): ReadableStream<Uint8Array> {
-  const encoder = new TextEncoder();
+export class NdJsonStream {
+  static headers = Object.freeze({ 'content-type': 'application/x-ndjson' });
 
-  function serialize(obj: Record<string, JSONValueType>) {
-    const serialized = JSON.stringify(obj);
-    return encoder.encode(`${serialized}\n`);
+  /**
+   * Converts a stream of JSON-serializable objects to newline-delimited JSON.
+   *
+   * Each object is wrapped with an object that specifies the `type` and references
+   * the `value`. The `type` is one of `chunk` or `data`. A type of `chunk` means that
+   * the `value` corresponds to chunks from the input stream. A type of `data` means
+   * that the `value` corresponds to the additional data provided as the second argument
+   * to this function.
+   *
+   *
+   * Example WITHOUT additional data:
+   *
+   *     const chunk = { key: 'value' };
+   *     const stream = new ReadableStream({start(con) { con.enqueue(chunk); con.close() }});
+   *     const ndJsonStream = NdJsonStream.from(stream);
+   *     const entries = [];
+   *     for await (const chunk of stream) {
+   *       entry.push(new TextDecoder().decode(chunk));
+   *     }
+   *     console.log(entries); // [ "{\"type\":\"chunk\",\"value\":{\"key\":\"value\"}}\n" ]
+   *
+   *
+   * Example WITH additional data:
+   *
+   *     const chunk = { key: 'value' };
+   *     const stream = new ReadableStream({start(con) { con.enqueue(chunk); con.close() }});
+   *     const ndJsonStream = NdJsonStream.from(stream, [{ extra: 'data' }]);
+   *     const entries = [];
+   *     for await (const chunk of stream) {
+   *       entry.push(new TextDecoder().decode(chunk));
+   *     }
+   *     console.log(entries); // [ "{\"type\":\"data\",\"value\":{\"extra\":\"data\"}}\n", "{\"type\":\"chunk\",\"value\":{\"key\":\"value\"}}\n" ]
+   *
+   *
+   * @param stream A readable stream of JSON-serializable chunks to encode as ndjson
+   * @param data Optional, additional data to prepend to the output stream
+   * @returns A readable stream of newline-delimited JSON
+   */
+  static from<T extends { [x: string]: JSONValueType }>(
+    stream: ReadableStream<T>,
+    data?: Record<string, JSONValueType> | Record<string, JSONValueType>[],
+  ): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+
+    function serialize(obj: Record<string, JSONValueType>) {
+      const serialized = JSON.stringify(obj);
+      return encoder.encode(`${serialized}\n`);
+    }
+
+    const ndJsonEncode = new TransformStream({
+      start(controller) {
+        if (!data) {
+          return;
+        }
+
+        for (const entry of Array.isArray(data) ? data : [data]) {
+          controller.enqueue(serialize({ type: 'data', value: entry }));
+        }
+      },
+
+      transform(chunk, controller) {
+        controller.enqueue(serialize({ type: 'chunk', value: chunk }));
+      },
+    });
+
+    return stream.pipeThrough(ndJsonEncode);
   }
-
-  const ndJsonEncode = new TransformStream({
-    start(controller) {
-      if (!data) {
-        return;
-      }
-
-      for (const entry of Array.isArray(data) ? data : [data]) {
-        controller.enqueue(serialize({ type: 'data', value: entry }));
-      }
-    },
-
-    transform(chunk, controller) {
-      controller.enqueue(serialize({ type: 'chunk', value: chunk }));
-    },
-  });
-
-  return stream.pipeThrough(ndJsonEncode);
 }
-
-StreamToNdJson.headers = Object.freeze({ 'Content-Type': 'application/x-ndjson' });
-
-Object.seal(StreamToNdJson);
-
-export { StreamToNdJson };

--- a/packages/models/test/openai/chat.test.ts
+++ b/packages/models/test/openai/chat.test.ts
@@ -7,7 +7,7 @@ import {
   NdJsonStreamToParsedObjects,
 } from '../utils';
 import { OpenAIChat, OpenAIChatTypes } from '../../src/openai/chat';
-import { StreamToIterable, StreamToNdJson } from '../../src/utils/stream';
+import { StreamToIterable, NdJsonStream } from '../../src/utils/stream';
 
 describe('openai chat', () => {
   let streamingChatResponse: string;
@@ -149,7 +149,7 @@ describe('openai chat', () => {
         { apiKey: 'sk-not-real', fetch: fetchSpy as any },
       );
 
-      const stream = StreamToNdJson(response);
+      const stream = NdJsonStream.from(response);
 
       let firstChunk: OpenAIChatTypes.Chunk | null = null;
       let lastChunk: OpenAIChatTypes.Chunk | null = null;

--- a/packages/models/test/utils.ts
+++ b/packages/models/test/utils.ts
@@ -52,3 +52,16 @@ export function createUnpredictableByteStream(blob: string) {
     },
   });
 }
+
+export function NdJsonStreamToParsedObjects(stream: ReadableStream<Uint8Array>) {
+  const decoder = new TextDecoder();
+
+  const parser = new TransformStream({
+    transform(chunk, controller) {
+      const serialized = decoder.decode(chunk).trimEnd();
+      controller.enqueue(JSON.parse(serialized));
+    },
+  });
+
+  return stream.pipeThrough(parser);
+}

--- a/packages/models/test/utils/stream.test.ts
+++ b/packages/models/test/utils/stream.test.ts
@@ -1,0 +1,66 @@
+import { StreamToIterable, StreamToNdJson } from '../../src/utils/stream';
+
+describe('StreamToNdJson', () => {
+  const chunks = [
+    { content: 'A' },
+    { content: ' Nd' },
+    { content: 'Json' },
+    { content: ' stream' },
+  ];
+
+  let source: ReadableStream<{ content: string }>;
+
+  beforeEach(() => {
+    source = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+  });
+
+  const decoder = new TextDecoder();
+
+  it('creates a special nd json formatted stream', async () => {
+    let ndjson: string[] = [];
+
+    const ndJsonStream = StreamToNdJson(source);
+
+    for await (const chunk of StreamToIterable(ndJsonStream)) {
+      ndjson.push(decoder.decode(chunk));
+    }
+
+    expect(ndjson).toEqual([
+      '{"type":"chunk","value":{"content":"A"}}\n',
+      '{"type":"chunk","value":{"content":" Nd"}}\n',
+      '{"type":"chunk","value":{"content":"Json"}}\n',
+      '{"type":"chunk","value":{"content":" stream"}}\n',
+    ]);
+  });
+
+  it('supports additional data prepended to the stream', async () => {
+    let ndjson: string[] = [];
+
+    const additionalData = [
+      { some: 'extra', data: 'here' },
+      { some: 'more', data: 'here' },
+    ];
+
+    const ndJsonStream = StreamToNdJson(source, additionalData);
+
+    for await (const chunk of StreamToIterable(ndJsonStream)) {
+      ndjson.push(decoder.decode(chunk));
+    }
+
+    expect(ndjson).toEqual([
+      '{"type":"data","value":{"some":"extra","data":"here"}}\n',
+      '{"type":"data","value":{"some":"more","data":"here"}}\n',
+      '{"type":"chunk","value":{"content":"A"}}\n',
+      '{"type":"chunk","value":{"content":" Nd"}}\n',
+      '{"type":"chunk","value":{"content":"Json"}}\n',
+      '{"type":"chunk","value":{"content":" stream"}}\n',
+    ]);
+  });
+});

--- a/packages/models/test/utils/stream.test.ts
+++ b/packages/models/test/utils/stream.test.ts
@@ -1,66 +1,72 @@
-import { StreamToIterable, StreamToNdJson } from '../../src/utils/stream';
+import { StreamToIterable, NdJsonStream } from '../../src/utils';
 
-describe('StreamToNdJson', () => {
-  const chunks = [
-    { content: 'A' },
-    { content: ' Nd' },
-    { content: 'Json' },
-    { content: ' stream' },
-  ];
+describe('NdJsonStream', () => {
+  describe('.from', () => {
+    const chunks = [
+      { content: 'A' },
+      { content: ' Nd' },
+      { content: 'Json' },
+      { content: ' stream' },
+    ];
 
-  let source: ReadableStream<{ content: string }>;
+    let source: ReadableStream<{ content: string }>;
 
-  beforeEach(() => {
-    source = new ReadableStream({
-      start(controller) {
-        for (const chunk of chunks) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
+    beforeEach(() => {
+      source = new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(chunk);
+          }
+          controller.close();
+        },
+      });
+    });
+
+    const decoder = new TextDecoder();
+
+    it('creates a special nd json formatted stream', async () => {
+      let ndjson: string[] = [];
+
+      const ndJsonStream = NdJsonStream.from(source);
+
+      for await (const chunk of StreamToIterable(ndJsonStream)) {
+        ndjson.push(decoder.decode(chunk));
+      }
+
+      expect(ndjson).toEqual([
+        '{"type":"chunk","value":{"content":"A"}}\n',
+        '{"type":"chunk","value":{"content":" Nd"}}\n',
+        '{"type":"chunk","value":{"content":"Json"}}\n',
+        '{"type":"chunk","value":{"content":" stream"}}\n',
+      ]);
+    });
+
+    it('supports additional data prepended to the stream', async () => {
+      let ndjson: string[] = [];
+
+      const additionalData = [
+        { some: 'extra', data: 'here' },
+        { some: 'more', data: 'here' },
+      ];
+
+      const ndJsonStream = NdJsonStream.from(source, additionalData);
+
+      for await (const chunk of StreamToIterable(ndJsonStream)) {
+        ndjson.push(decoder.decode(chunk));
+      }
+
+      expect(ndjson).toEqual([
+        '{"type":"data","value":{"some":"extra","data":"here"}}\n',
+        '{"type":"data","value":{"some":"more","data":"here"}}\n',
+        '{"type":"chunk","value":{"content":"A"}}\n',
+        '{"type":"chunk","value":{"content":" Nd"}}\n',
+        '{"type":"chunk","value":{"content":"Json"}}\n',
+        '{"type":"chunk","value":{"content":" stream"}}\n',
+      ]);
     });
   });
 
-  const decoder = new TextDecoder();
-
-  it('creates a special nd json formatted stream', async () => {
-    let ndjson: string[] = [];
-
-    const ndJsonStream = StreamToNdJson(source);
-
-    for await (const chunk of StreamToIterable(ndJsonStream)) {
-      ndjson.push(decoder.decode(chunk));
-    }
-
-    expect(ndjson).toEqual([
-      '{"type":"chunk","value":{"content":"A"}}\n',
-      '{"type":"chunk","value":{"content":" Nd"}}\n',
-      '{"type":"chunk","value":{"content":"Json"}}\n',
-      '{"type":"chunk","value":{"content":" stream"}}\n',
-    ]);
-  });
-
-  it('supports additional data prepended to the stream', async () => {
-    let ndjson: string[] = [];
-
-    const additionalData = [
-      { some: 'extra', data: 'here' },
-      { some: 'more', data: 'here' },
-    ];
-
-    const ndJsonStream = StreamToNdJson(source, additionalData);
-
-    for await (const chunk of StreamToIterable(ndJsonStream)) {
-      ndjson.push(decoder.decode(chunk));
-    }
-
-    expect(ndjson).toEqual([
-      '{"type":"data","value":{"some":"extra","data":"here"}}\n',
-      '{"type":"data","value":{"some":"more","data":"here"}}\n',
-      '{"type":"chunk","value":{"content":"A"}}\n',
-      '{"type":"chunk","value":{"content":" Nd"}}\n',
-      '{"type":"chunk","value":{"content":"Json"}}\n',
-      '{"type":"chunk","value":{"content":" stream"}}\n',
-    ]);
+  it('specifies headers', () => {
+    expect(NdJsonStream.headers).toEqual({ 'content-type': 'application/x-ndjson' });
   });
 });


### PR DESCRIPTION
This library will encourage [newline-delimited JSON](http://ndjson.org) as the "standard" interface for streaming data from API endpoints. The popular model APIs all stream chunks a little differently. Converting each stream to ND JSON will allow us to build reusable client utilities, e.g., a `useChat` react hook on the frontend.

For example, say we have the following list of objects that we're going to stream:

```ts
const stream = createReadableStreamFrom([
  { content: "Some" },
  { content: " content" },
  { content: " goes" },
  { content: " here" },
  { content: "." },
]);
```

When we convert this stream to ND JSON using the `NdJsonStream` utility, we get:

```ts
for (const chunk of NdJsonStream.from(stream)) {
  console.log(new TextDecoder().decode(chunk));
}
```

```txt
{"type":"chunk","value":{"content":"Some"}}\n
{"type":"chunk","value":{"content":" content"}}\n
{"type":"chunk","value":{"content":" goes"}}\n
{"type":"chunk","value":{"content":" here"}}\n
{"type":"chunk","value":{"content":"."}}\n
```

This format ^ is what we'll encourage for our streaming representation.

If you want to prepend additional data to the stream, you can supply an object or a list of objects to the `NdJsonStream.from` method as the second argument:

```ts
for (const chunk of NdJsonStream.from(stream, [{ additional: "data" }, { goes: "here" }])) {
  console.log(new TextDecoder().decode(chunk));
}
```

```txt
{"type":"data","value":{"additional":"data"}}\n
{"type":"data","value":{"goes":"here"}}\n
{"type":"chunk","value":{"content":"Some"}}\n
{"type":"chunk","value":{"content":" content"}}\n
{"type":"chunk","value":{"content":" goes"}}\n
{"type":"chunk","value":{"content":" here"}}\n
{"type":"chunk","value":{"content":"."}}\n
```

Lastly, the `NdJsonStream` has a `headers` property defined on it with the proper HTTP response headers. This can be convenient when creating API routes. For example:

```ts
function POST(request: NextRequest) {
  const chatRequest = await request.json();

  const stream = await OpenAIChat.stream(chatRequest, {
    apiKey: process.env.OPENAI_API_KEY!,
  });

  return new Response(NdJsonStream.from(stream), { headers: NdJsonStream.headers });
}
```