### PR TITLE
Updates to useChat and streaming models

### DIFF
--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -8,7 +8,8 @@ npm i @axflow/models
 
 ## Features
 
-* Zero-dependency, lightweight package to consume all the most popular LLMs, embedding models, and more
+* Zero-dependency, modular package to consume all the most popular LLMs, embedding models, and more
+* Comes with a set of React hooks for easily creating robust completion and chat components
 * Built exclusively on modern web standards such as `fetch` and the stream APIs
 * First-class streaming support with both low-level byte streams or higher-level JavaScript objects
 * Supports Node 18+, Next.js serverless or edge runtime, browsers, ESM, CJS, and more
@@ -60,6 +61,32 @@ for await (const chunk of StreamToIterable(gpt4Stream)) {
 for await (const chunk of StreamToIterable(cohereStream)) {
   console.log(chunk.text);
 }
+```
+
+For models that support streaming, there is a convenience method for streaming only the string tokens.
+
+```ts
+import {OpenAIChat} from '@axflow/models/openai/chat';
+
+const tokenStream = OpenAIChat.streamTokens(
+  {
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: 'What is the Eiffel tower?' }],
+  },
+  {
+    apiKey: '<openai api key>',
+  },
+);
+
+// Example stdout output:
+//
+// The Eiffel Tower is a renowned wrought-iron landmark located in Paris, France, known globally as a symbol of romance and elegance.
+//
+for await (const token of tokenStream) {
+  process.stdout.write(token);
+}
+
+process.stdout.write("\n");
 ```
 
 ## Next.js edge proxy example
@@ -115,23 +142,25 @@ for await (const chunk of StreamToIterable(stream)) {
 ### @axflow/models/openai/chat
 
 ```ts
-import {OpenAIChat, OpenAIChatDecoderStream} from '@axflow/models/openai/chat';
+import {OpenAIChat} from '@axflow/models/openai/chat';
 import type {OpenAIChatTypes} from '@axflow/models/openai/chat';
 
 OpenAIChat.run(/* args */)
 OpenAIChat.stream(/* args */)
 OpenAIChat.streamBytes(/* args */)
+OpenAIChat.streamTokens(/* args */)
 ```
 
 ### @axflow/models/openai/completion
 
 ```ts
-import {OpenAICompletion, OpenAICompletionDecoderStream} from '@axflow/models/openai/completion';
+import {OpenAICompletion} from '@axflow/models/openai/completion';
 import type {OpenAICompletionTypes} from '@axflow/models/openai/completion';
 
 OpenAICompletion.run(/* args */)
 OpenAICompletion.stream(/* args */)
 OpenAICompletion.streamBytes(/* args */)
+OpenAICompletion.streamTokens(/* args */)
 ```
 
 ### @axflow/models/openai/embedding
@@ -146,12 +175,13 @@ OpenAIEmbedding.run(/* args */)
 ### @axflow/models/cohere/generation
 
 ```ts
-import {CohereGeneration, CohereGenerationDecoderStream} from '@axflow/models/cohere/generation';
+import {CohereGeneration} from '@axflow/models/cohere/generation';
 import type {CohereGenerationTypes} from '@axflow/models/cohere/generation';
 
 CohereGeneration.run(/* args */)
 CohereGeneration.stream(/* args */)
 CohereGeneration.streamBytes(/* args */)
+CohereGeneration.streamTokens(/* args */)
 ```
 
 ### @axflow/models/cohere/embedding
@@ -166,13 +196,23 @@ CohereEmbedding.run(/* args */)
 ### @axflow/models/anthropic/completion
 
 ```ts
-import {AnthropicCompletion, AnthropicCompletionDecoderStream} from '@axflow/models/anthropic/completion';
+import {AnthropicCompletion} from '@axflow/models/anthropic/completion';
 import type {AnthropicCompletionTypes} from '@axflow/models/anthropic/completion';
 
 AnthropicCompletion.run(/* args */)
 AnthropicCompletion.stream(/* args */)
 AnthropicCompletion.streamBytes(/* args */)
+AnthropicCompletion.streamTokens(/* args */)
 ```
+
+### @axflow/models/react
+
+```ts
+import {useChat} from '@axflow/models/react';
+import type {UseChatOptionsType, UseChatResultType} from '@axflow/models/shared';
+```
+
+`useChat` is a react hook that makes building chat componets a breeze.
 
 ### @axflow/models/shared
 

--- a/packages/models/src/react/use-chat.ts
+++ b/packages/models/src/react/use-chat.ts
@@ -100,7 +100,9 @@ async function stableAppend(
 
 const DEFAULT_URL = '/api/chat';
 const DEFAULT_ACCESSOR = (value: string) => value;
-const DEFAULT_BODY = (message: MessageType, history: MessageType[]) => ({ message, history });
+const DEFAULT_BODY = (message: MessageType, history: MessageType[]) => ({
+  messages: [...history, message],
+});
 const DEFAULT_HEADERS = {};
 
 /**
@@ -123,9 +125,9 @@ export type UseChatOptionsType = {
    * argument and the history (an array of previous messages) as its second argument.
    *
    * If given an object, the object will be merged into the request body with the
-   * new message and the message history, e.g., `{...body, message, history }`.
+   * full set of messages, i.e., `{...body, messages }`.
    *
-   * By default, the request body is `{ message, history }`.
+   * By default, the request body is `{ messages }`.
    */
   body?: BodyType;
 
@@ -203,7 +205,7 @@ export type UseChatResultType = {
  * @returns UseChatResultType
  */
 export function useChat(options?: UseChatOptionsType): UseChatResultType {
-  options = options ?? {};
+  options ??= {};
 
   const [input, setInput] = useState<string>(options.initialInput ?? '');
   const [messages, _setMessages] = useState<MessageType[]>(options.initialMessages ?? []);
@@ -218,10 +220,10 @@ export function useChat(options?: UseChatOptionsType): UseChatResultType {
     [messagesRef, _setMessages],
   );
 
-  const url = options.url || DEFAULT_URL;
-  const accessor = options.accessor || DEFAULT_ACCESSOR;
-  const body = options.body || DEFAULT_BODY;
-  const headers = options.headers || DEFAULT_HEADERS;
+  const url = options.url ?? DEFAULT_URL;
+  const accessor = options.accessor ?? DEFAULT_ACCESSOR;
+  const body = options.body ?? DEFAULT_BODY;
+  const headers = options.headers ?? DEFAULT_HEADERS;
 
   function append(message: MessageType) {
     stableAppend(message, messagesRef, setMessages, url, headers, body, accessor);

--- a/packages/models/src/shared/stream.ts
+++ b/packages/models/src/shared/stream.ts
@@ -38,7 +38,7 @@ async function* createIterable<T>(stream: ReadableStream<T>): AsyncIterable<T> {
   }
 }
 
-function identity<T>(value: T) {
+function identity<T>(value: T): T {
   return value;
 }
 

--- a/packages/models/test/anthropic/completion.test.ts
+++ b/packages/models/test/anthropic/completion.test.ts
@@ -120,4 +120,29 @@ describe('anthropic completion', () => {
       });
     });
   });
+
+  describe('streamTokens', () => {
+    it('streams only the tokens', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingCompletionResponse),
+      });
+
+      const response = await AnthropicCompletion.streamTokens(
+        {
+          model: 'claude-2',
+          prompt: '\n\nHuman: Hello, world!\n\nAssistant:',
+          max_tokens_to_sample: 256,
+        },
+        { apiKey: 'sk-not-real', fetch: fetchSpy as any },
+      );
+
+      let resultingText = '';
+
+      for await (const chunk of StreamToIterable(response)) {
+        resultingText += chunk;
+      }
+
+      expect(resultingText).toEqual(' Hello!');
+    });
+  });
 });

--- a/packages/models/test/cohere/generation.test.ts
+++ b/packages/models/test/cohere/generation.test.ts
@@ -122,4 +122,30 @@ describe('cohere generation', () => {
       });
     });
   });
+
+  describe('streamTokens', () => {
+    it('streams only the tokens', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingGenerationResponse),
+      });
+
+      const response = await CohereGeneration.streamTokens(
+        {
+          prompt: 'Please explain to me how LLMs work in two sentences or less',
+          max_tokens: 80,
+        },
+        { apiKey: 'sk-not-real', fetch: fetchSpy as any },
+      );
+
+      let resultingText = '';
+
+      for await (const chunk of StreamToIterable(response)) {
+        resultingText += chunk;
+      }
+
+      expect(resultingText).toEqual(
+        ' LLMs work by using a large amount of data to train a model that can then be used to generate text. The model is trained to predict the next word in a sequence based on the words that came before it.',
+      );
+    });
+  });
 });

--- a/packages/models/test/openai/chat.test.ts
+++ b/packages/models/test/openai/chat.test.ts
@@ -192,4 +192,32 @@ describe('openai chat', () => {
       ]);
     });
   });
+
+  describe('streamTokens', () => {
+    it('streams only the tokens', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingChatResponse),
+      });
+
+      const response = await OpenAIChat.streamTokens(
+        {
+          model: 'gpt-4',
+          messages: [
+            { role: 'user', content: 'Using no more than 20 words, what is the Eiffel tower?' },
+          ],
+        },
+        { apiKey: 'sk-not-real', fetch: fetchSpy as any },
+      );
+
+      let resultingText = '';
+
+      for await (const chunk of StreamToIterable(response)) {
+        resultingText += chunk;
+      }
+
+      expect(resultingText).toEqual(
+        'The Eiffel Tower is a renowned wrought-iron landmark located in Paris, France, known globally as a symbol of romance and elegance.',
+      );
+    });
+  });
 });

--- a/packages/models/test/openai/chat.test.ts
+++ b/packages/models/test/openai/chat.test.ts
@@ -146,7 +146,7 @@ describe('openai chat', () => {
         { apiKey: 'sk-not-real', fetch: fetchSpy as any },
       );
 
-      const stream = StreamingJsonResponse(response, {
+      const stream = new StreamingJsonResponse(response, {
         data: [{ auxiliary: 'data' }],
         map: (chunk) => chunk.choices[0].delta.content || '',
       });

--- a/packages/models/test/openai/completion.test.ts
+++ b/packages/models/test/openai/completion.test.ts
@@ -127,4 +127,31 @@ describe('openai chat', () => {
       });
     });
   });
+
+  describe('streamTokens', () => {
+    it('streams only the tokens', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingChatResponse),
+      });
+
+      const response = await OpenAICompletion.streamTokens(
+        {
+          model: 'text-davinci-003',
+          prompt: 'Using no more than 20 words, what is the Eiffel tower?',
+          max_tokens: 256,
+        },
+        { apiKey: 'sk-not-real', fetch: fetchSpy as any },
+      );
+
+      let resultingText = '';
+
+      for await (const chunk of StreamToIterable(response)) {
+        resultingText += chunk;
+      }
+
+      expect(resultingText).toEqual(
+        '\n\nIconic iron lattice tower in Paris, France, measuring 324 meters tall.',
+      );
+    });
+  });
 });

--- a/packages/models/test/shared/stream.test.ts
+++ b/packages/models/test/shared/stream.test.ts
@@ -156,7 +156,7 @@ describe('streams', () => {
 
   describe('StreamingJsonResponse', () => {
     it('can create a ndjson response', async () => {
-      const response = StreamingJsonResponse(source, {
+      const response = new StreamingJsonResponse(source, {
         map(chunk) {
           return chunk.content;
         },


### PR DESCRIPTION
* Simplify the default API contract (body) for the useChat hook
* Make `StreamingChatResponse` a subclass of `Response`
* Add `streamTokens` to the streaming models for convenience.
* Remove the transform stream implementations as there is currently no need for those to be public and I want to minimize the interface surface area.

With this in place, defining a Next.js edge route that connects to our `useChat` react hook is dead simple. Below is a working example:

```ts
///////////////////
// On the server //
///////////////////
import { OpenAIChat } from '@axflow/models/openai/chat';
import { StreamingJsonResponse, type MessageType } from '@axflow/models/shared';

export const runtime = 'edge';

export async function POST(request: Request) {
  const { messages } = await request.json();

  const stream = await OpenAIChat.streamTokens(
    {
      model: 'gpt-4',
      messages: messages.map((msg: MessageType) => ({ role: msg.role, content: msg.content })),
    },
    {
      apiKey: process.env.OPENAI_API_KEY!,
    },
  );

  return new StreamingJsonResponse(stream);
}

///////////////////
// On the client //
///////////////////
import { useChat } from '@axflow/models/react';

function ChatComponent() {
  const {input, messages, onChange, onSubmit} = useChat();

  return (
    <>
      <Messages messages={messages} />
      <Form input={input} onChange={onChange} onSubmit={onSubmit} />
    </>
  );
}
```

That example is using OpenAI chat models, but it looks exactly the same for OpenAI completion, Cohere, and Anthropic models.