### PR TITLE
Remove stream map functionality for now

### DIFF
--- a/packages/models/test/openai/chat.test.ts
+++ b/packages/models/test/openai/chat.test.ts
@@ -3,8 +3,7 @@ import Path from 'node:path';
 
 import { createFakeFetch, createUnpredictableByteStream } from '../utils';
 import { OpenAIChat } from '../../src/openai/chat';
-import { StreamToIterable, NdJsonStream, StreamingJsonResponse } from '../../src/shared';
-import type { NdJsonValueType } from '../../src/shared';
+import { StreamToIterable } from '../../src/shared';
 
 describe('openai chat', () => {
   let streamingChatResponse: string;
@@ -129,67 +128,6 @@ describe('openai chat', () => {
         ],
         stream: true,
       });
-    });
-
-    it('can create a streaming json response', async () => {
-      const fetchSpy = createFakeFetch({
-        body: createUnpredictableByteStream(streamingChatResponse),
-      });
-
-      const response = await OpenAIChat.stream(
-        {
-          model: 'gpt-4',
-          messages: [
-            { role: 'user', content: 'Using no more than 20 words, what is the Eiffel tower?' },
-          ],
-        },
-        { apiKey: 'sk-not-real', fetch: fetchSpy as any },
-      );
-
-      const stream = new StreamingJsonResponse(response, {
-        data: [{ auxiliary: 'data' }],
-        map: (chunk) => chunk.choices[0].delta.content || '',
-      });
-
-      const chunks: NdJsonValueType[] = [];
-
-      for await (const chunk of StreamToIterable(NdJsonStream.decode(stream.body!))) {
-        chunks.push(chunk);
-      }
-
-      expect(chunks).toEqual([
-        { type: 'data', value: { auxiliary: 'data' } },
-        { type: 'chunk', value: '' },
-        { type: 'chunk', value: 'The' },
-        { type: 'chunk', value: ' E' },
-        { type: 'chunk', value: 'iff' },
-        { type: 'chunk', value: 'el' },
-        { type: 'chunk', value: ' Tower' },
-        { type: 'chunk', value: ' is' },
-        { type: 'chunk', value: ' a' },
-        { type: 'chunk', value: ' renowned' },
-        { type: 'chunk', value: ' wrought' },
-        { type: 'chunk', value: '-' },
-        { type: 'chunk', value: 'iron' },
-        { type: 'chunk', value: ' landmark' },
-        { type: 'chunk', value: ' located' },
-        { type: 'chunk', value: ' in' },
-        { type: 'chunk', value: ' Paris' },
-        { type: 'chunk', value: ',' },
-        { type: 'chunk', value: ' France' },
-        { type: 'chunk', value: ',' },
-        { type: 'chunk', value: ' known' },
-        { type: 'chunk', value: ' globally' },
-        { type: 'chunk', value: ' as' },
-        { type: 'chunk', value: ' a' },
-        { type: 'chunk', value: ' symbol' },
-        { type: 'chunk', value: ' of' },
-        { type: 'chunk', value: ' romance' },
-        { type: 'chunk', value: ' and' },
-        { type: 'chunk', value: ' elegance' },
-        { type: 'chunk', value: '.' },
-        { type: 'chunk', value: '' },
-      ]);
     });
   });
 

--- a/packages/models/test/shared/stream.test.ts
+++ b/packages/models/test/shared/stream.test.ts
@@ -73,54 +73,6 @@ describe('streams', () => {
           '{"type":"chunk","value":{"content":" stream"}}\n',
         ]);
       });
-
-      it('can map the stream chunks', async () => {
-        const ndJsonStream = NdJsonStream.encode(source, {
-          map(chunk) {
-            return chunk.content;
-          },
-        });
-
-        let ndjson: string[] = [];
-
-        for await (const chunk of StreamToIterable(ndJsonStream)) {
-          ndjson.push(decoder.decode(chunk));
-        }
-
-        expect(ndjson).toEqual([
-          '{"type":"chunk","value":"A"}\n',
-          '{"type":"chunk","value":" Nd"}\n',
-          '{"type":"chunk","value":"Json"}\n',
-          '{"type":"chunk","value":" stream"}\n',
-        ]);
-      });
-
-      it('can asynchronously map the stream chunks', async () => {
-        function delay<T>(ms: number, value: T): Promise<T> {
-          return new Promise((resolve) => {
-            setTimeout(() => resolve(value), ms);
-          });
-        }
-
-        const ndJsonStream = NdJsonStream.encode(source, {
-          map(chunk) {
-            return delay(1, chunk.content);
-          },
-        });
-
-        let ndjson: string[] = [];
-
-        for await (const chunk of StreamToIterable(ndJsonStream)) {
-          ndjson.push(decoder.decode(chunk));
-        }
-
-        expect(ndjson).toEqual([
-          '{"type":"chunk","value":"A"}\n',
-          '{"type":"chunk","value":" Nd"}\n',
-          '{"type":"chunk","value":"Json"}\n',
-          '{"type":"chunk","value":" stream"}\n',
-        ]);
-      });
     });
 
     describe('.decode', () => {
@@ -156,10 +108,13 @@ describe('streams', () => {
 
   describe('StreamingJsonResponse', () => {
     it('can create a ndjson response', async () => {
+      const additionalData = [
+        { some: 'extra', data: 'here' },
+        { some: 'more', data: 'here' },
+      ];
+
       const response = new StreamingJsonResponse(source, {
-        map(chunk) {
-          return chunk.content;
-        },
+        data: additionalData,
       });
 
       expect(response.ok).toBe(true);
@@ -173,10 +128,12 @@ describe('streams', () => {
       }
 
       expect(ndjson).toEqual([
-        '{"type":"chunk","value":"A"}\n',
-        '{"type":"chunk","value":" Nd"}\n',
-        '{"type":"chunk","value":"Json"}\n',
-        '{"type":"chunk","value":" stream"}\n',
+        '{"type":"data","value":{"some":"extra","data":"here"}}\n',
+        '{"type":"data","value":{"some":"more","data":"here"}}\n',
+        '{"type":"chunk","value":{"content":"A"}}\n',
+        '{"type":"chunk","value":{"content":" Nd"}}\n',
+        '{"type":"chunk","value":{"content":"Json"}}\n',
+        '{"type":"chunk","value":{"content":" stream"}}\n',
       ]);
     });
   });


### PR DESCRIPTION
This was some sugar that I am removing for now. I think it's really useful, but I think it needs some extra consideration, so punting on it for now.

In particular, what I want out of the response stream mapping would be:

1. Async + Sync mapping (already the case in this implementation that I'm removing)
2. I want to filter out some values. Some of the streams return entries without tokens (e.g., openai returns a chunk with a finish reason and no tokens, I want to filter this out from the token stream).
3. I want to be able to enqueue arbitrary data in addition to the stream chunks, per out streaming interface.
4. I *may* want additional error handling capabilities (but this might be handled by returning a rejected promise, so not sure).

Something that looks close to this:

```ts
// API response
return new StreamingJsonResponse(stream, {
  // We want to support async / sync mapping
  async map(chunk, controller) {
    // We may want to filter some chunks out.
    if (!chunk.someProperty) {
      return;
    }

    try {
      const {transformedChunk, someMetadata} = await transformChunkAsync(chunk);
      // Enqueue the chunk like a normal stream controller enqueue call
      controller.enqueue(transformedChunk);
      // Send additional data / metadata to the client alongside the stream
      controller.enqueueData(someMetadata);
    } catch (error) {
      // Some errors may be problematic enough that we want to error the stream. Others we can ignore.
      if (error.fatal) {
        controller.error(error);
      }
    }
  }
});
```

This needs more though, so removing for now and will come back to this later.