### PR TITLE
Add IterableToStream utility

### DIFF
--- a/docs/documentation/models.md
+++ b/docs/documentation/models.md
@@ -267,6 +267,13 @@ import type {UseChatOptionsType, UseChatResultType} from '@axflow/models/shared'
 ### @axflow/models/shared
 
 ```ts
-import {StreamToIterable, NdJsonStream, StreamingJsonResponse, HttpError, isHttpError} from '@axflow/models/shared';
+import {
+  IterableToStream,
+  StreamToIterable,
+  NdJsonStream,
+  StreamingJsonResponse,
+  HttpError,
+  isHttpError
+} from '@axflow/models/shared';
 import type {NdJsonValueType, JSONValueType, MessageType} from '@axflow/models/shared';
 ```

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -267,6 +267,13 @@ import type {UseChatOptionsType, UseChatResultType} from '@axflow/models/shared'
 ### @axflow/models/shared
 
 ```ts
-import {StreamToIterable, NdJsonStream, StreamingJsonResponse, HttpError, isHttpError} from '@axflow/models/shared';
+import {
+  IterableToStream,
+  StreamToIterable,
+  NdJsonStream,
+  StreamingJsonResponse,
+  HttpError,
+  isHttpError
+} from '@axflow/models/shared';
 import type {NdJsonValueType, JSONValueType, MessageType} from '@axflow/models/shared';
 ```

--- a/packages/models/src/shared/index.ts
+++ b/packages/models/src/shared/index.ts
@@ -1,6 +1,6 @@
 export { HttpError, isHttpError, POST } from './http';
 
-export { StreamToIterable, NdJsonStream, StreamingJsonResponse } from './stream';
+export { IterableToStream, StreamToIterable, NdJsonStream, StreamingJsonResponse } from './stream';
 
 export type { NdJsonValueType } from './stream';
 

--- a/packages/models/test/shared/stream.test.ts
+++ b/packages/models/test/shared/stream.test.ts
@@ -1,4 +1,9 @@
-import { StreamToIterable, NdJsonStream, StreamingJsonResponse } from '../../src/shared';
+import {
+  IterableToStream,
+  StreamToIterable,
+  NdJsonStream,
+  StreamingJsonResponse,
+} from '../../src/shared';
 import type { NdJsonValueType } from '../../src/shared';
 import { createUnpredictableByteStream } from '../utils';
 
@@ -243,6 +248,33 @@ describe('streams', () => {
         '{"type":"data","value":{"some":"extra","data":"here"}}\n',
         '{"type":"data","value":{"some":"more","data":"here"}}\n',
       ]);
+    });
+  });
+
+  describe('IterableToStream', () => {
+    it('can convert an async iterable to a readable stream', async () => {
+      const iterable = (async function* () {
+        for (const chunk of chunks) {
+          yield delay(0, chunk);
+        }
+      })();
+
+      const stream = IterableToStream(iterable);
+      const reader = stream.getReader();
+
+      let contents = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          break;
+        }
+
+        contents += value.content;
+      }
+
+      expect(contents).toEqual('A NdJson stream');
     });
   });
 });


### PR DESCRIPTION
This is helpful for "bringing your own models" that return an async iterable, yet our utilities like `StreamingJsonResponse` expect a stream. This bridges the two.