### PR TITLE
Change text-davinci-003 -> gpt-3.5-turbo

### DIFF
--- a/packages/axeval/README.md
+++ b/packages/axeval/README.md
@@ -108,8 +108,8 @@ const claude2 = new AnthropicCompletion("claude-2", { temperature: 1 });
 runner.register("Claude2 completion", claude2, tests);
 
 // Register another suite of tests that test the OpenAI Davinci model
-const davinci3 = new OpenAICompletion("gpt-3.5-turbo-instruct");
-runner.register("gpt-3.5-turbo-instruct completion", davinci3, tests);
+const davinci3 = new OpenAICompletion("gpt-3.5-turbo");
+runner.register("gpt-3.5-turbo completion", davinci3, tests);
 
 // Run the tests
 runner.run();

--- a/packages/axeval/README.md
+++ b/packages/axeval/README.md
@@ -109,7 +109,7 @@ runner.register("Claude2 completion", claude2, tests);
 
 // Register another suite of tests that test the OpenAI Davinci model
 const davinci3 = new OpenAICompletion("gpt-3.5-turbo-instruct");
-runner.register("text-davinci-003 completion", davinci3, tests);
+runner.register("gpt-3.5-turbo-instruct completion", davinci3, tests);
 
 // Run the tests
 runner.run();

--- a/packages/axeval/README.md
+++ b/packages/axeval/README.md
@@ -108,7 +108,7 @@ const claude2 = new AnthropicCompletion("claude-2", { temperature: 1 });
 runner.register("Claude2 completion", claude2, tests);
 
 // Register another suite of tests that test the OpenAI Davinci model
-const davinci3 = new OpenAICompletion("text-davinci-003");
+const davinci3 = new OpenAICompletion("gpt-3.5-turbo-instruct");
 runner.register("text-davinci-003 completion", davinci3, tests);
 
 // Run the tests


### PR DESCRIPTION
As the title states, this exchanges the "text-davinci-003" model which was shut down as of January 4th, 2024, to the new recommended model "gpt-3.5-turbo". Thus the example code no longer runs, you'll get something like:

```
return new NotFoundError(status, error, message, headers);
                   ^

NotFoundError: 404 The model `text-davinci-003` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations
    at APIError.generate (/Users/chris/playground/llm-testing/axeval/node_modules/openai/error.js:53:20)
    at OpenAI.makeStatusError (/Users/chris/playground/llm-testing/axeval/node_modules/openai/core.js:263:33)
    at OpenAI.makeRequest (/Users/chris/playground/llm-testing/axeval/node_modules/openai/core.js:306:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async OpenAICompletion.run (/Users/chris/playground/llm-testing/axeval/node_modules/axeval/dist/model.js:83:26)
    at async time (/Users/chris/playground/llm-testing/axeval/node_modules/axeval/dist/utils.js:10:20)
    at async Runner.runCase (/Users/chris/playground/llm-testing/axeval/node_modules/axeval/dist/runner.js:35:51)
    at async Runner.runSuite (/Users/chris/playground/llm-testing/axeval/node_modules/axeval/dist/runner.js:30:26)
    at async time (/Users/chris/playground/llm-testing/axeval/node_modules/axeval/dist/utils.js:10:20)
    at async /Users/chris/playground/llm-testing/axeval/node_modules/axeval/dist/runner.js:17:57
```

More about the OpenAI deprecations here: https://platform.openai.com/docs/deprecations